### PR TITLE
Connect frontend to Cloud Run backend via API_BASE_URL

### DIFF
--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -1,3 +1,4 @@
+import os
 from pathlib import Path
 
 from fastapi import FastAPI
@@ -9,9 +10,11 @@ from api.routers import auth, events, feed, feedback, locations, websites
 
 app = FastAPI(title="Momaverse API")
 
+cors_origins = os.environ.get("CORS_ORIGINS", "*").split(",")
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=cors_origins,
     allow_credentials=True,
     allow_methods=["GET", "POST", "PUT", "DELETE"],
     allow_headers=["*"],

--- a/build.js
+++ b/build.js
@@ -46,7 +46,11 @@ async function build(isDev) {
         throw new Error('No JS files found in index.html');
     }
 
-    // Concatenate JS: flatpickr first, then app modules in order
+    // Inject API_BASE_URL from environment (defaults to '' for relative URLs in local dev)
+    const apiBaseUrl = process.env.API_BASE_URL || '';
+    const apiBaseUrlDecl = `var API_BASE_URL = ${JSON.stringify(apiBaseUrl)};\n`;
+
+    // Concatenate JS: config, flatpickr, then app modules in order
     const flatpickrJs = fs.readFileSync(FLATPICKR_JS, 'utf8');
     let originalJsSize = 0;
     const appJs = jsFiles.map(f => {
@@ -55,7 +59,7 @@ async function build(isDev) {
         originalJsSize += Buffer.byteLength(content, 'utf8');
         return content;
     }).join('\n;\n');
-    const concatenated = flatpickrJs + '\n;\n' + appJs;
+    const concatenated = apiBaseUrlDecl + flatpickrJs + '\n;\n' + appJs;
 
     // Minify JS in prod, pass through in dev
     let jsContent;

--- a/infrastructure/backend.tf
+++ b/infrastructure/backend.tf
@@ -12,11 +12,10 @@ terraform {
     }
   }
 
-  # Uncomment after creating the bucket with: gsutil mb gs://momaverse-terraform-state
-  # backend "gcs" {
-  #   bucket = "momaverse-terraform-state"
-  #   prefix = "terraform/state"
-  # }
+  backend "gcs" {
+    bucket = "momaverse-terraform-state"
+    prefix = "terraform/state"
+  }
 }
 
 provider "google" {

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -17,6 +17,7 @@ resource "google_project_service" "apis" {
     "vpcaccess.googleapis.com",
     "cloudscheduler.googleapis.com",
     "compute.googleapis.com",
+    "servicenetworking.googleapis.com",
   ])
   service            = each.value
   disable_on_destroy = false
@@ -259,6 +260,10 @@ resource "google_cloud_run_v2_service" "backend" {
       env {
         name  = "ENVIRONMENT"
         value = "production"
+      }
+      env {
+        name  = "CORS_ORIGINS"
+        value = "https://storage.googleapis.com"
       }
       env {
         name  = "DB_HOST"

--- a/src/js/script.js
+++ b/src/js/script.js
@@ -100,10 +100,10 @@ document.addEventListener('DOMContentLoaded', () => {
          * @property {number} MAP_MAX_ZOOM - Maximum zoom level
          */
         config: {
-            EVENT_INIT_URL: '/api/v1/feed/events',
-            LOCATIONS_INIT_URL: '/api/v1/feed/locations',
-            EVENT_FULL_URL: '/api/v1/feed/events',
-            LOCATIONS_FULL_URL: '/api/v1/feed/locations',
+            EVENT_INIT_URL: API_BASE_URL + '/api/v1/feed/events',
+            LOCATIONS_INIT_URL: API_BASE_URL + '/api/v1/feed/locations',
+            EVENT_FULL_URL: API_BASE_URL + '/api/v1/feed/events',
+            LOCATIONS_FULL_URL: API_BASE_URL + '/api/v1/feed/locations',
             TAG_CONFIG_URL: 'data/tags.json',
             RELATED_TAGS_URL: 'data/related_tags.json',
 

--- a/src/js/ui/feedbackManager.js
+++ b/src/js/ui/feedbackManager.js
@@ -18,7 +18,7 @@ const FeedbackManager = (() => {
     // ========================================
 
     const CONFIG = {
-        API_ENDPOINT: '/api/v1/feedback/',
+        API_ENDPOINT: API_BASE_URL + '/api/v1/feedback/',
         MAX_LENGTH: 10000
     };
 


### PR DESCRIPTION
## Summary

- Inject `API_BASE_URL` at build time so the GCS-hosted frontend can reach the Cloud Run backend
- Tighten CORS in backend to read allowed origins from `CORS_ORIGINS` env var (defaults to `*` for local dev)
- Add `CORS_ORIGINS=https://storage.googleapis.com` to Cloud Run service in Terraform
- Enable GCS terraform state backend and add `servicenetworking.googleapis.com` API

## How it works

- **Local dev:** No env var needed — `API_BASE_URL` defaults to `""`, relative URLs work as before
- **Production:** `API_BASE_URL=https://momaverse-backend-5j2cl2xnyq-uc.a.run.app npm run build`

## Test plan

- [ ] `npm run build` with no env var → verify relative URLs in bundle
- [ ] `API_BASE_URL=https://example.com npm run build` → verify absolute URLs in bundle
- [ ] Deploy backend with new CORS config, verify `Access-Control-Allow-Origin` header
- [ ] Upload `dist/` to GCS bucket, verify frontend can reach Cloud Run API

Closes #61