### PR TITLE
Add admin promotion endpoint and fix Dockerfile for deploy

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -14,6 +14,8 @@ WORKDIR /app
 
 COPY --from=builder /app/.venv /app/.venv
 COPY api/ ./api/
+COPY alembic/ ./alembic/
+COPY alembic.ini ./
 
 RUN adduser --disabled-password --no-create-home appuser
 USER appuser
@@ -21,4 +23,4 @@ USER appuser
 ENV PATH="/app/.venv/bin:$PATH"
 
 EXPOSE 8080
-CMD ["uvicorn", "api.main:app", "--host", "0.0.0.0", "--port", "8080"]
+CMD ["sh", "-c", "alembic upgrade head && uvicorn api.main:app --host 0.0.0.0 --port 8080 --proxy-headers --forwarded-allow-ips='*'"]

--- a/backend/api/routers/auth.py
+++ b/backend/api/routers/auth.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter, HTTPException, Response, status
 from sqlalchemy import func, select
 from sqlalchemy.exc import IntegrityError
 
+from api.config import get_settings
 from api.dependencies import (
     CurrentUserDep,
     SessionDep,
@@ -81,3 +82,29 @@ async def logout(_user: CurrentUserDep) -> Response:
 @router.get("/me", response_model=UserResponse)
 async def me(user: CurrentUserDep) -> UserResponse:
     return UserResponse.model_validate(user)
+
+
+@router.post("/promote-admin", status_code=status.HTTP_200_OK)
+async def promote_admin(
+    email: str,
+    api_key: str,
+    db: SessionDep,
+) -> dict[str, str]:
+    """Promote a user to admin. Secured by SYNC_API_KEY."""
+    settings = get_settings()
+    if api_key != settings.sync_api_key:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Invalid API key",
+        )
+
+    user = await db.scalar(select(User).where(User.email == email))
+    if user is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="User not found",
+        )
+
+    user.is_admin = True
+    await db.commit()
+    return {"message": f"{email} is now an admin"}


### PR DESCRIPTION
## Summary
- Add `/api/v1/auth/promote-admin` endpoint secured by `SYNC_API_KEY` to promote users to admin role
- Fix Dockerfile: include `alembic/` and `alembic.ini` so migrations run on deploy
- Add `--proxy-headers --forwarded-allow-ips='*'` to uvicorn so sqladmin static assets load correctly behind Cloud Run (HTTPS)

## Test plan
- [ ] Deploy to Cloud Run and verify `/admin` loads with CSS/JS
- [ ] Call `promote-admin` with valid API key and confirm user becomes admin
- [ ] Confirm `alembic upgrade head` runs on container startup


🤖 Generated with [Claude Code](https://claude.com/claude-code)