### PR TITLE
Hide soft-deleted records from admin views

### DIFF
--- a/backend/api/admin/views.py
+++ b/backend/api/admin/views.py
@@ -1,6 +1,8 @@
 """SQLAdmin ModelAdmin views for all Momaverse models."""
 
 from sqladmin import ModelView
+from sqlalchemy import Select, func, select
+from starlette.requests import Request
 
 from api.models.crawl import CrawlContent, CrawlJob, CrawlResult, ExtractedEvent
 from api.models.event import Event, EventOccurrence, EventSource
@@ -21,6 +23,15 @@ class LocationAdmin(ModelView, model=Location):
     column_list = ["id", "name", "address", "lat", "lng", "emoji", "type"]
     column_searchable_list = ["name"]
 
+    def list_query(self, request: Request) -> Select:  # type: ignore[type-arg]
+        return select(Location).where(Location.active())
+
+    def count_query(self, request: Request) -> Select:  # type: ignore[type-arg]
+        return select(func.count(Location.id)).where(Location.active())
+
+    def details_query(self, request: Request) -> Select:  # type: ignore[type-arg]
+        return select(Location).where(Location.active())
+
 
 class SourceAdmin(ModelView, model=Source):
     name = "Source"
@@ -35,6 +46,15 @@ class SourceAdmin(ModelView, model=Source):
     ]
     column_searchable_list = ["name"]
 
+    def list_query(self, request: Request) -> Select:  # type: ignore[type-arg]
+        return select(Source).where(Source.active())
+
+    def count_query(self, request: Request) -> Select:  # type: ignore[type-arg]
+        return select(func.count(Source.id)).where(Source.active())
+
+    def details_query(self, request: Request) -> Select:  # type: ignore[type-arg]
+        return select(Source).where(Source.active())
+
 
 class EventAdmin(ModelView, model=Event):
     name = "Event"
@@ -48,6 +68,15 @@ class EventAdmin(ModelView, model=Event):
         "status",
     ]
     column_searchable_list = ["name"]
+
+    def list_query(self, request: Request) -> Select:  # type: ignore[type-arg]
+        return select(Event).where(Event.active())
+
+    def count_query(self, request: Request) -> Select:  # type: ignore[type-arg]
+        return select(func.count(Event.id)).where(Event.active())
+
+    def details_query(self, request: Request) -> Select:  # type: ignore[type-arg]
+        return select(Event).where(Event.active())
 
 
 class TagAdmin(ModelView, model=Tag):
@@ -129,6 +158,15 @@ class TagRuleAdmin(ModelView, model=TagRule):
     name_plural = "Tag Rules"
     icon = "fa-solid fa-gavel"
     column_list = ["id", "rule_type", "pattern", "replacement"]
+
+    def list_query(self, request: Request) -> Select:  # type: ignore[type-arg]
+        return select(TagRule).where(TagRule.active())
+
+    def count_query(self, request: Request) -> Select:  # type: ignore[type-arg]
+        return select(func.count(TagRule.id)).where(TagRule.active())
+
+    def details_query(self, request: Request) -> Select:  # type: ignore[type-arg]
+        return select(TagRule).where(TagRule.active())
 
 
 class EventOccurrenceAdmin(ModelView, model=EventOccurrence):

--- a/backend/tests/test_admin_views.py
+++ b/backend/tests/test_admin_views.py
@@ -1,0 +1,144 @@
+"""Tests for soft-delete filtering in SQLAdmin views."""
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from sqlalchemy import func, select
+from sqlalchemy.orm import DeclarativeBase
+
+from api.admin.views import EventAdmin, LocationAdmin, SourceAdmin, TagRuleAdmin
+from api.models.event import Event
+from api.models.location import Location
+from api.models.source import Source
+from api.models.tag import TagRule
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+# Maps each admin class to the model it manages
+_SOFT_DELETE_VIEWS: list[tuple[type, type[DeclarativeBase]]] = [
+    (LocationAdmin, Location),
+    (SourceAdmin, Source),
+    (EventAdmin, Event),
+    (TagRuleAdmin, TagRule),
+]
+
+_VIEW_IDS = ["LocationAdmin", "SourceAdmin", "EventAdmin", "TagRuleAdmin"]
+
+
+def _fake_request() -> Any:
+    """Return a minimal mock request for query methods."""
+    return MagicMock()
+
+
+def _compile_where(stmt: Any) -> str:
+    """Compile a statement's WHERE clause to a string for assertion."""
+    return str(stmt.compile(compile_kwargs={"literal_binds": True}))
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("admin_cls", "model_cls"),
+    _SOFT_DELETE_VIEWS,
+    ids=_VIEW_IDS,
+)
+def test_list_query_filters_soft_deleted(
+    admin_cls: type, model_cls: type[DeclarativeBase]
+) -> None:
+    """list_query should include a WHERE clause filtering on deleted_at IS NULL."""
+    admin = admin_cls()
+    query = admin.list_query(_fake_request())
+
+    compiled = _compile_where(query)
+    assert "deleted_at IS NULL" in compiled
+
+    # The FROM clause should match
+    assert model_cls.__tablename__ in compiled
+
+
+@pytest.mark.parametrize(
+    ("admin_cls", "model_cls"),
+    _SOFT_DELETE_VIEWS,
+    ids=_VIEW_IDS,
+)
+def test_count_query_filters_soft_deleted(
+    admin_cls: type, model_cls: type[DeclarativeBase]
+) -> None:
+    """count_query should count only active (non-deleted) records."""
+    admin = admin_cls()
+    query = admin.count_query(_fake_request())
+
+    compiled = _compile_where(query)
+    assert "deleted_at IS NULL" in compiled
+
+    # Verify it uses count()
+    assert "count(" in compiled.lower()
+
+
+@pytest.mark.parametrize(
+    ("admin_cls", "model_cls"),
+    _SOFT_DELETE_VIEWS,
+    ids=_VIEW_IDS,
+)
+def test_details_query_filters_soft_deleted(
+    admin_cls: type, model_cls: type[DeclarativeBase]
+) -> None:
+    """details_query should filter out soft-deleted records."""
+    admin = admin_cls()
+    query = admin.details_query(_fake_request())
+
+    compiled = _compile_where(query)
+    assert "deleted_at IS NULL" in compiled
+    assert model_cls.__tablename__ in compiled
+
+
+@pytest.mark.parametrize(
+    ("admin_cls", "model_cls"),
+    _SOFT_DELETE_VIEWS,
+    ids=_VIEW_IDS,
+)
+def test_list_query_matches_expected_shape(
+    admin_cls: type, model_cls: type[DeclarativeBase]
+) -> None:
+    """list_query should return a select(Model).where(Model.active()) equivalent."""
+    admin = admin_cls()
+    actual = str(
+        admin.list_query(_fake_request()).compile(
+            compile_kwargs={"literal_binds": True}
+        )
+    )
+    expected = str(
+        select(model_cls)
+        .where(model_cls.active())  # type: ignore[attr-defined]
+        .compile(compile_kwargs={"literal_binds": True})
+    )
+    assert actual == expected
+
+
+@pytest.mark.parametrize(
+    ("admin_cls", "model_cls"),
+    _SOFT_DELETE_VIEWS,
+    ids=_VIEW_IDS,
+)
+def test_count_query_matches_expected_shape(
+    admin_cls: type, model_cls: type[DeclarativeBase]
+) -> None:
+    """count_query should return select(func.count(Model.id)).where(Model.active())."""
+    admin = admin_cls()
+    actual = str(
+        admin.count_query(_fake_request()).compile(
+            compile_kwargs={"literal_binds": True}
+        )
+    )
+    expected = str(
+        select(func.count(model_cls.id))  # type: ignore[attr-defined]
+        .where(model_cls.active())  # type: ignore[attr-defined]
+        .compile(compile_kwargs={"literal_binds": True})
+    )
+    assert actual == expected


### PR DESCRIPTION
## Summary
- Override `list_query`, `count_query`, and `details_query` on `LocationAdmin`, `SourceAdmin`, `EventAdmin`, and `TagRuleAdmin` to filter with `.active()` (`deleted_at IS NULL`)
- Soft-deleted records no longer appear in SQLAdmin list, count, or detail views
- Add 20 parametrized tests verifying the query filtering

## Test plan
- [x] `pytest` — 39/39 passed
- [x] `mypy` — 0 errors
- [ ] Manual: soft-delete a record via API, confirm it disappears from admin dashboard

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)