### PR TITLE
feat: integrate geocoding into processor for new locations

### DIFF
--- a/pipeline/processor.py
+++ b/pipeline/processor.py
@@ -19,6 +19,7 @@ from datetime import datetime, timedelta
 import db
 import regex
 from crawler import create_safe_filename
+from geocoding import geocode_location_name
 
 # Blocked emoji characters that render poorly
 BLOCKED_EMOJI = {
@@ -1097,13 +1098,30 @@ def process_events(cursor, connection, crawl_result_id, website_name, run_date_s
                     (new_location_id, location_name[:255]),
                 )
 
+                # Geocode the new location
+                geo_lat = None
+                geo_lng = None
+                geo_address = None
+                try:
+                    geo_result = geocode_location_name(location_name)
+                    if geo_result is not None:
+                        geo_lat = geo_result.lat
+                        geo_lng = geo_result.lng
+                        geo_address = geo_result.formatted_address
+                        cursor.execute(
+                            "UPDATE locations SET lat = %s, lng = %s, address = %s WHERE id = %s",
+                            (geo_lat, geo_lng, geo_address, new_location_id),
+                        )
+                except Exception:
+                    pass  # Geocoding failure must not block processing
+
                 # Add to locations_map so subsequent events at same venue match
                 new_info = {
                     "id": new_location_id,
                     "name": location_name,
-                    "address": None,
-                    "lat": None,
-                    "lng": None,
+                    "address": geo_address,
+                    "lat": geo_lat,
+                    "lng": geo_lng,
                     "emoji": None,
                 }
                 locations_map["names"][location_name.lower()] = new_info


### PR DESCRIPTION
## What
Integrate the geocoding module into `processor.py` so newly created locations are immediately geocoded.

## Why
When the processor creates a new location (no match found), it previously left lat/lng/address as NULL. This PR calls `geocode_location_name()` right after the INSERT, updates the DB row with coordinates, and populates the in-memory `locations_map` so subsequent events in the same batch benefit.

Closes #94 (part 2/3)

## How
Added a geocoding call after the location alternate name INSERT in the new-location creation block. On success, UPDATEs the location row with lat/lng/address. On failure, silently catches the exception to avoid blocking event processing.

## Changes
- `pipeline/processor.py`: Import `geocode_location_name`, call it after new location INSERT, UPDATE DB on success, populate `new_info` dict with coordinates

## Validation
- [x] ruff check
- [x] ruff format
- [x] mypy
- [x] pytest

## Stack
PR 2/3 for: Auto-geocode new locations during pipeline processing


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Location records now automatically include geographic coordinates and precise addresses, improving data accuracy and completeness.

* **Bug Fixes**
  * Enhanced error handling ensures location processing remains uninterrupted, even when temporary issues arise during data enrichment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->