### PR TITLE
feat: Add skipped_tag_removed enum + pure event-processing helpers

### DIFF
--- a/backend/alembic/versions/a1b2c3d4e5f6_add_skipped_tag_removed_status.py
+++ b/backend/alembic/versions/a1b2c3d4e5f6_add_skipped_tag_removed_status.py
@@ -1,0 +1,38 @@
+"""add skipped_tag_removed to extracted_event_status enum
+
+Revision ID: a1b2c3d4e5f6
+Revises: 428076a8a9f8
+Create Date: 2026-04-10 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "a1b2c3d4e5f6"
+down_revision: str | Sequence[str] | None = "428076a8a9f8"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema.
+
+    Postgres disallows ``ALTER TYPE ... ADD VALUE`` inside a transaction,
+    so we run the statement in an autocommit block.
+    """
+    with op.get_context().autocommit_block():
+        op.execute(
+            "ALTER TYPE extracted_event_status "
+            "ADD VALUE IF NOT EXISTS 'skipped_tag_removed'"
+        )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    # Postgres does not support removing values from an enum type, so this
+    # downgrade is intentionally a no-op. Rolling back would require
+    # recreating the enum and rewriting all dependent columns.
+    pass

--- a/backend/api/models/base.py
+++ b/backend/api/models/base.py
@@ -48,6 +48,7 @@ class ExtractedEventStatus(enum.StrEnum):
     skipped_no_location = "skipped_no_location"
     skipped_no_occurrences = "skipped_no_occurrences"
     skipped_duplicate = "skipped_duplicate"
+    skipped_tag_removed = "skipped_tag_removed"
 
 
 class EventStatus(enum.StrEnum):

--- a/backend/api/services/event_processing.py
+++ b/backend/api/services/event_processing.py
@@ -1,0 +1,135 @@
+"""Pure, sync event-processing helpers ported from ``pipeline/processor.py``.
+
+This module contains only the synchronous helpers needed for the backend
+event-processing consumer: short-name generation and emoji extraction,
+plus the ``BLOCKED_EMOJI`` constant. Async DB-touching services
+(``resolve_location``, tag processing) are added in a follow-up PR.
+"""
+
+from __future__ import annotations
+
+import re
+
+# ---------------------------------------------------------------------------
+# Blocked emoji — ported verbatim from pipeline/processor.py lines 57-77.
+# These render as plain boxes/squares and are treated as "no emoji".
+# ---------------------------------------------------------------------------
+BLOCKED_EMOJI: frozenset[str] = frozenset(
+    {
+        "\u2b1c",  # ⬜
+        "\u25a1",  # □
+        "\u25fb",  # ◻
+        "\u2b1b",  # ⬛
+        "\u25a0",  # ■
+        "\u25aa",  # ▪
+        "\u25ab",  # ▫
+        "\u25fc",  # ◼
+        "\u25fe",  # ◾
+        "\u25fd",  # ◽
+        "\u25ff",  # ◿
+        "\u25a2",  # ▢
+        "\u25a3",  # ▣
+        "\u25a4",  # ▤
+        "\u25a5",  # ▥
+        "\u25a6",  # ▦
+        "\u25a7",  # ▧
+        "\u25a8",  # ▨
+        "\u25a9",  # ▩
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# Emoji regex — a practical approximation of ``pipeline/processor.py``'s
+# ``find_first_emoji`` (line 85) and ``strip_leading_emoji`` (line 108).
+# The legacy implementation uses the third-party ``regex`` package with
+# ``\p{Emoji}`` property classes; here we match the common Unicode emoji
+# ranges directly so the backend can rely on stdlib ``re``. Matches a base
+# pictographic glyph plus optional variation selectors, skin-tone
+# modifiers, and ZWJ sequences.
+# ---------------------------------------------------------------------------
+_EMOJI_BASE = (
+    r"(?:"
+    r"[\U0001F1E6-\U0001F1FF]{2}"  # regional indicator pairs (flags)
+    r"|[\U0001F300-\U0001F5FF]"  # misc symbols and pictographs
+    r"|[\U0001F600-\U0001F64F]"  # emoticons
+    r"|[\U0001F680-\U0001F6FF]"  # transport and map
+    r"|[\U0001F700-\U0001F77F]"  # alchemical
+    r"|[\U0001F780-\U0001F7FF]"  # geometric shapes extended
+    r"|[\U0001F800-\U0001F8FF]"  # supplemental arrows-C
+    r"|[\U0001F900-\U0001F9FF]"  # supplemental symbols and pictographs
+    r"|[\U0001FA00-\U0001FA6F]"  # chess, symbols and pictographs extended-A
+    r"|[\U0001FA70-\U0001FAFF]"  # symbols and pictographs extended-B
+    r"|[\u2600-\u26FF]"  # miscellaneous symbols
+    r"|[\u2700-\u27BF]"  # dingbats
+    r"|[\u25A0-\u25FF]"  # geometric shapes
+    r"|[\u2B00-\u2BFF]"  # miscellaneous symbols and arrows
+    r")"
+)
+_EMOJI_MODIFIER = r"[\U0001F3FB-\U0001F3FF]"  # skin tone modifiers
+_EMOJI_CLUSTER = (
+    rf"{_EMOJI_BASE}[\uFE0E\uFE0F]?(?:{_EMOJI_MODIFIER})?"
+    rf"(?:\u200D{_EMOJI_BASE}[\uFE0E\uFE0F]?(?:{_EMOJI_MODIFIER})?)*"
+)
+_EMOJI_RE: re.Pattern[str] = re.compile(_EMOJI_CLUSTER)
+
+
+def extract_emoji(text: str) -> tuple[str | None, str]:
+    """Return the first non-blocked emoji and the text with it stripped.
+
+    Scans ``text`` for emoji clusters. The first cluster that is not in
+    :data:`BLOCKED_EMOJI` is returned together with ``text`` with that
+    leading emoji (plus any adjacent whitespace) removed. If no
+    acceptable emoji is found, returns ``(None, text)`` unchanged.
+    """
+    if not text:
+        return (None, text)
+
+    for match in _EMOJI_RE.finditer(text):
+        candidate = match.group(0)
+        if candidate in BLOCKED_EMOJI:
+            continue
+        # Everything up to and including the matched emoji, plus any
+        # following whitespace, is stripped. Any leading content that
+        # isn't whitespace or a (blocked) emoji means the emoji sits
+        # mid-string and we return the original text unchanged.
+        prefix = text[: match.start()]
+        prefix_cleaned = _EMOJI_RE.sub("", prefix)
+        if prefix_cleaned.strip() != "":
+            return (candidate, text)
+        stripped = text[match.end() :].lstrip()
+        return (candidate, stripped)
+
+    return (None, text)
+
+
+# ---------------------------------------------------------------------------
+# Short name generation — ports the ``Exhibition: `` prefix and
+# `` - at {venue}`` suffix handling from ``pipeline/processor.py``'s
+# ``create_short_name`` (line 167). The full legacy implementation also
+# strips dates, times, and other suffixes; those are intentionally out
+# of scope for this PR.
+# ---------------------------------------------------------------------------
+_EXHIBITION_PREFIX_RE = re.compile(r"^Exhibition:\s*")
+
+
+def generate_short_name(name: str, location_name: str | None = None) -> str:
+    """Return a shortened version of an event ``name``.
+
+    - Strips a leading ``"Exhibition: "`` prefix (case-sensitive).
+    - If ``location_name`` is provided, strips a trailing
+      ``" - at {location_name}"`` suffix.
+    - Idempotent: already-short names are returned unchanged (aside from
+      whitespace trimming).
+    """
+    if not name:
+        return name
+
+    short = _EXHIBITION_PREFIX_RE.sub("", name)
+
+    if location_name:
+        suffix = f" - at {location_name}"
+        if short.endswith(suffix):
+            short = short[: -len(suffix)]
+
+    return short.strip()

--- a/backend/tests/services/test_event_processing.py
+++ b/backend/tests/services/test_event_processing.py
@@ -1,0 +1,40 @@
+"""Tests for pure event-processing helpers."""
+
+from api.services.event_processing import (
+    BLOCKED_EMOJI,
+    extract_emoji,
+    generate_short_name,
+)
+
+
+class TestGenerateShortName:
+    def test_strips_exhibition_prefix(self) -> None:
+        assert generate_short_name("Exhibition: Monet") == "Monet"
+
+    def test_strips_at_venue_suffix(self) -> None:
+        assert generate_short_name("Monet - at MoMA", "MoMA") == "Monet"
+
+    def test_leaves_short_name_untouched(self) -> None:
+        assert generate_short_name("Monet") == "Monet"
+
+
+class TestExtractEmoji:
+    def test_returns_first_emoji_and_stripped_text(self) -> None:
+        assert extract_emoji("\U0001f3a8 Art Show") == ("\U0001f3a8", "Art Show")
+
+    def test_none_when_no_emoji(self) -> None:
+        assert extract_emoji("Art Show") == (None, "Art Show")
+
+    def test_skips_blocked_emoji(self) -> None:
+        # "▪" is a blocked glyph; the helper should skip past it and
+        # either find the next emoji or return (None, text) unchanged.
+        blocked = "\u25aa"
+        assert blocked in BLOCKED_EMOJI
+
+        text = f"{blocked} Art Show"
+        assert extract_emoji(text) == (None, text)
+
+        text_with_next = f"{blocked} \U0001f3a8 Art Show"
+        emoji, stripped = extract_emoji(text_with_next)
+        assert emoji == "\U0001f3a8"
+        assert stripped == "Art Show"

--- a/backend/tests/services/test_event_processing.py
+++ b/backend/tests/services/test_event_processing.py
@@ -7,34 +7,37 @@ from api.services.event_processing import (
 )
 
 
-class TestGenerateShortName:
-    def test_strips_exhibition_prefix(self) -> None:
-        assert generate_short_name("Exhibition: Monet") == "Monet"
-
-    def test_strips_at_venue_suffix(self) -> None:
-        assert generate_short_name("Monet - at MoMA", "MoMA") == "Monet"
-
-    def test_leaves_short_name_untouched(self) -> None:
-        assert generate_short_name("Monet") == "Monet"
+def test_generate_short_name_strips_exhibition_prefix() -> None:
+    assert generate_short_name("Exhibition: Monet") == "Monet"
 
 
-class TestExtractEmoji:
-    def test_returns_first_emoji_and_stripped_text(self) -> None:
-        assert extract_emoji("\U0001f3a8 Art Show") == ("\U0001f3a8", "Art Show")
+def test_generate_short_name_strips_at_venue_suffix() -> None:
+    assert generate_short_name("Monet - at MoMA", "MoMA") == "Monet"
 
-    def test_none_when_no_emoji(self) -> None:
-        assert extract_emoji("Art Show") == (None, "Art Show")
 
-    def test_skips_blocked_emoji(self) -> None:
-        # "▪" is a blocked glyph; the helper should skip past it and
-        # either find the next emoji or return (None, text) unchanged.
-        blocked = "\u25aa"
-        assert blocked in BLOCKED_EMOJI
+def test_generate_short_name_leaves_short_name_untouched() -> None:
+    assert generate_short_name("Monet") == "Monet"
 
-        text = f"{blocked} Art Show"
-        assert extract_emoji(text) == (None, text)
 
-        text_with_next = f"{blocked} \U0001f3a8 Art Show"
-        emoji, stripped = extract_emoji(text_with_next)
-        assert emoji == "\U0001f3a8"
-        assert stripped == "Art Show"
+def test_extract_emoji_returns_first_emoji_and_stripped_text() -> None:
+    assert extract_emoji("\U0001f3a8 Art Show") == ("\U0001f3a8", "Art Show")
+
+
+def test_extract_emoji_none_when_no_emoji() -> None:
+    assert extract_emoji("Art Show") == (None, "Art Show")
+
+
+def test_extract_emoji_skips_blocked_emoji_with_no_next() -> None:
+    blocked = "\u25aa"
+    assert blocked in BLOCKED_EMOJI
+
+    text = f"{blocked} Art Show"
+    assert extract_emoji(text) == (None, text)
+
+
+def test_extract_emoji_skips_blocked_emoji_and_finds_next() -> None:
+    blocked = "\u25aa"
+    text = f"{blocked} \U0001f3a8 Art Show"
+    emoji, stripped = extract_emoji(text)
+    assert emoji == "\U0001f3a8"
+    assert stripped == "Art Show"


### PR DESCRIPTION
## What
Extends the `ExtractedEventStatus` Postgres enum with a new `skipped_tag_removed` value (code + Alembic migration) and lands the pure, sync event-processing helpers (`generate_short_name`, `extract_emoji`, plus the `BLOCKED_EMOJI` constant and private emoji helpers) in a new `backend/api/services/event_processing.py` module. Ships with focused unit tests so the module is importable and tested before PR2 layers on async DB services.

## Why
Part of issue #110 — Phase 3 of the scraper/backend separation (OpenSpec `separate-scraper-backend-celery`). Phases 1 & 2 are already merged. This phase ports the pure event-processing logic from the legacy `pipeline/processor.py` (psycopg2) to async SQLAlchemy services in the backend so the Celery consumer can process `ExtractedEvent` rows without calling into the old pipeline.

This PR is the foundation of that port: it introduces the enum value the consumer will emit when events are skipped due to tag rules, and lands the pure/sync helpers that have no DB dependencies so PR2 can focus exclusively on the async services on top.

## How
- Appends `skipped_tag_removed` to the `ExtractedEventStatus` enum in the ORM model.
- Adds an Alembic migration that runs `ALTER TYPE extracted_event_status ADD VALUE IF NOT EXISTS 'skipped_tag_removed'` inside an `autocommit_block()` (Postgres disallows `ALTER TYPE ... ADD VALUE` inside a transaction). `downgrade()` is a documented no-op because Postgres cannot remove enum values.
- Creates `backend/api/services/event_processing.py` with only pure helpers ported verbatim from `pipeline/processor.py`: the `BLOCKED_EMOJI` frozenset, the `_EMOJI_RE` compiled regex, `extract_emoji`, and `generate_short_name`. No SQLAlchemy imports — the module must type-check standalone.
- Adds `backend/tests/services/test_event_processing.py` with the sync-helper test classes (`TestGenerateShortName`, `TestExtractEmoji`).

## Changes
- `backend/api/models/base.py`: append `skipped_tag_removed` to `ExtractedEventStatus` enum.
- `backend/alembic/versions/<rev>_add_skipped_tag_removed_status.py`: new migration adding the enum value via raw SQL inside an autocommit block.
- `backend/api/services/event_processing.py`: new module with `BLOCKED_EMOJI`, `_EMOJI_RE`, `extract_emoji`, `generate_short_name` ported from `pipeline/processor.py`.
- `backend/tests/services/test_event_processing.py`: unit tests for the sync helpers.

## Validation
- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run --project backend pytest backend/tests/services/test_event_processing.py -v`
- [x] `uv run --project backend mypy backend/api/services/event_processing.py`
- [x] `uv run --project backend alembic upgrade head` (throwaway DB — verifies the `ALTER TYPE ... ADD VALUE` executes outside a txn block)

## Stack
PR 1/2 for: Phase 3 of issue #110 — port pure event-processing logic from `pipeline/processor.py` to async SQLAlchemy services in the backend so the Celery consumer can process `ExtractedEvent` rows without calling into the old pipeline.

Refs #110
