### PR TITLE
feat: Add async resolve_location + tag processing services

### DIFF
--- a/backend/api/services/event_processing.py
+++ b/backend/api/services/event_processing.py
@@ -1,14 +1,25 @@
-"""Pure, sync event-processing helpers ported from ``pipeline/processor.py``.
+"""Event-processing helpers ported from ``pipeline/processor.py``.
 
-This module contains only the synchronous helpers needed for the backend
-event-processing consumer: short-name generation and emoji extraction,
-plus the ``BLOCKED_EMOJI`` constant. Async DB-touching services
-(``resolve_location``, tag processing) are added in a follow-up PR.
+This module contains the synchronous pure helpers (short-name generation,
+emoji extraction) as well as the async DB-touching services
+(``resolve_location``, ``load_tag_rules``, ``process_tags``,
+``should_skip_for_tags``) used by the backend event-processing consumer.
 """
 
 from __future__ import annotations
 
 import re
+from dataclasses import dataclass
+from difflib import SequenceMatcher
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from api.models.base import TagRuleType
+from api.models.location import Location
+from api.models.tag import TagRule
+from api.tasks.geocoding import geocode_location
 
 # ---------------------------------------------------------------------------
 # Blocked emoji — ported verbatim from pipeline/processor.py lines 57-77.
@@ -133,3 +144,261 @@ def generate_short_name(name: str, location_name: str | None = None) -> str:
             short = short[: -len(suffix)]
 
     return short.strip()
+
+
+# ---------------------------------------------------------------------------
+# Tag processing — ported from ``pipeline/processor.py`` (lines 262, 336).
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class TagRules:
+    """Bucketed tag rules keyed by normalized pattern.
+
+    - ``rewrites``: normalized pattern -> replacement string.
+    - ``excludes``: normalized patterns whose tags are dropped.
+    - ``removals``: normalized patterns whose presence means "skip event".
+    """
+
+    rewrites: dict[str, str]
+    excludes: frozenset[str]
+    removals: frozenset[str]
+
+
+def _normalize_tag_key(tag: str) -> str:
+    """Normalize a tag for rewrite/exclude/remove lookups."""
+    return tag.lower().replace(" ", "")
+
+
+def _normalize_location_name(name: str | None) -> str:
+    """Normalize a location name for matching.
+
+    Ported from ``pipeline/processor.py:586``. Lowercases, strips
+    punctuation, drops leading ``"the "`` on longer names, and treats
+    ``virtual``/``online``/``livestream`` as non-matches.
+    """
+    if not name:
+        return ""
+
+    original_lower = name.lower()
+    normalized = re.sub(r"[^\w\s]", "", original_lower)
+
+    if normalized in {"virtual", "online", "livestream"}:
+        return ""
+    if len(normalized) > 15 and normalized.startswith("the "):
+        normalized = normalized[4:]
+
+    return " ".join(normalized.split())
+
+
+def _normalize_street_address(addr: str | None) -> str | None:
+    """Normalize a street address for matching.
+
+    Ported from ``pipeline/processor.py:639``. Returns ``None`` if the
+    input is ``None``/empty or shorter than 5 characters after
+    normalization.
+    """
+    if not addr:
+        return None
+
+    normalized = addr.lower().strip()
+    replacements = [
+        ("avenue", "ave"),
+        ("street", "st"),
+        ("boulevard", "blvd"),
+        ("drive", "dr"),
+        ("road", "rd"),
+        ("place", "pl"),
+        ("court", "ct"),
+        ("lane", "ln"),
+        ("parkway", "pkwy"),
+        ("highway", "hwy"),
+        ("east", "e"),
+        ("west", "w"),
+        ("north", "n"),
+        ("south", "s"),
+    ]
+    for long_form, short_form in replacements:
+        normalized = re.sub(r"\b" + long_form + r"\b", short_form, normalized)
+
+    return normalized if len(normalized) >= 5 else None
+
+
+async def load_tag_rules(db: AsyncSession) -> TagRules:
+    """Load active tag rules from the DB, bucketed by ``TagRuleType``."""
+    stmt = select(TagRule).where(TagRule.deleted_at.is_(None))
+    result = await db.execute(stmt)
+    rules = result.scalars().all()
+
+    rewrites: dict[str, str] = {}
+    excludes: set[str] = set()
+    removals: set[str] = set()
+
+    for rule in rules:
+        key = _normalize_tag_key(rule.pattern)
+        if rule.rule_type == TagRuleType.rewrite:
+            if rule.replacement is not None:
+                rewrites[key] = rule.replacement
+        elif rule.rule_type == TagRuleType.exclude:
+            excludes.add(key)
+        elif rule.rule_type == TagRuleType.remove:
+            removals.add(key)
+
+    return TagRules(
+        rewrites=rewrites,
+        excludes=frozenset(excludes),
+        removals=frozenset(removals),
+    )
+
+
+def _coerce_raw_tags(raw_tags: list[str] | str | None) -> list[str]:
+    """Coerce the raw tag payload (list, hash-delimited string, or None)."""
+    if raw_tags is None:
+        return []
+    if isinstance(raw_tags, list):
+        return [tag.strip() for tag in raw_tags if tag and tag.strip()]
+    return [
+        tag.strip().rstrip(",") for tag in raw_tags.split("#") if tag and tag.strip()
+    ]
+
+
+async def process_tags(
+    raw_tags: list[str] | str | None,
+    rules: TagRules,
+    *,
+    extra_tags: list[str] | None = None,
+) -> list[str]:
+    """Normalize, rewrite, and de-duplicate tags.
+
+    Ported from ``pipeline/processor.py:262`` (simplified). Applies
+    rewrite rules, drops tags in ``rules.excludes``, appends
+    ``extra_tags``, and de-duplicates while preserving order.
+    """
+    tags = _coerce_raw_tags(raw_tags)
+    processed: list[str] = []
+    seen: set[str] = set()
+
+    if extra_tags:
+        for tag in extra_tags:
+            key = _normalize_tag_key(tag)
+            if not key or key in rules.excludes or key in seen:
+                continue
+            processed.append(tag)
+            seen.add(key)
+
+    for tag in tags:
+        lookup = _normalize_tag_key(tag)
+        final = rules.rewrites.get(lookup, tag)
+        final_key = _normalize_tag_key(final)
+        if not final_key or final_key in rules.excludes or final_key in seen:
+            continue
+        processed.append(final)
+        seen.add(final_key)
+
+    return processed
+
+
+def should_skip_for_tags(tags: list[str], rules: TagRules) -> bool:
+    """Return ``True`` iff any tag matches a removal rule.
+
+    Ported from ``pipeline/processor.py:336`` (``filter_by_tag``). The
+    legacy helper returned ``True`` when the event should be *kept*; this
+    inverts the sense to match the function name.
+    """
+    normalized = {_normalize_tag_key(tag) for tag in tags}
+    return not normalized.isdisjoint(rules.removals)
+
+
+# ---------------------------------------------------------------------------
+# Location resolution — ported from ``pipeline/processor.py:769``.
+# ---------------------------------------------------------------------------
+
+_FUZZY_THRESHOLD = 0.85
+_DEFAULT_LOCATION_EMOJI = "\U0001f3ad"  # 🎭
+
+
+async def resolve_location(
+    db: AsyncSession,
+    *,
+    location_name: str | None,
+    sublocation: str | None,
+    source_site_name: str,
+    event_name: str,
+) -> Location | None:
+    """Resolve a ``Location`` for an extracted event.
+
+    Matching order:
+      1. Exact match on normalized ``Location.name``.
+      2. Exact match on any normalized ``LocationAlternateName``.
+      3. Fuzzy match via :class:`difflib.SequenceMatcher` with ratio
+         >= 0.85 against normalized names.
+      4. Fallback exact match on ``source_site_name`` or ``event_name``.
+
+    If no match is found, a new :class:`Location` is created, flushed to
+    obtain its ``id``, and a :func:`geocode_location` Celery task is
+    enqueued. The caller owns the transaction: this function never
+    commits.
+    """
+    if not location_name:
+        return None
+
+    normalized_loc = _normalize_location_name(location_name)
+    normalized_sub = _normalize_location_name(sublocation)
+    normalized_event = _normalize_location_name(event_name)
+    normalized_site = _normalize_location_name(source_site_name)
+
+    full_loc = f"{normalized_loc} {normalized_sub}".strip()
+
+    stmt = select(Location).options(selectinload(Location.alternate_names))
+    result = await db.execute(stmt)
+    locations = list(result.scalars().all())
+
+    search_keys = [k for k in (normalized_loc, full_loc) if k]
+
+    # Step 1: exact match on normalized Location.name
+    for loc in locations:
+        if _normalize_location_name(loc.name) in search_keys:
+            return loc
+
+    # Step 2: exact match on any normalized alternate name
+    for loc in locations:
+        for alt in loc.alternate_names:
+            if _normalize_location_name(alt.alternate_name) in search_keys:
+                return loc
+
+    # Step 3: fuzzy match via SequenceMatcher ratio >= threshold
+    best_loc: Location | None = None
+    best_score = 0.0
+    for loc in locations:
+        candidates = [_normalize_location_name(loc.name)] + [
+            _normalize_location_name(alt.alternate_name) for alt in loc.alternate_names
+        ]
+        for candidate in candidates:
+            if not candidate:
+                continue
+            for key in search_keys:
+                if not key:
+                    continue
+                score = SequenceMatcher(None, candidate, key).ratio()
+                if score >= _FUZZY_THRESHOLD and score > best_score:
+                    best_loc = loc
+                    best_score = score
+    if best_loc is not None:
+        return best_loc
+
+    # Step 4: fallback on source_site_name / event_name exact normalized match
+    fallback_keys = [k for k in (normalized_site, normalized_event) if k]
+    if fallback_keys:
+        for loc in locations:
+            if _normalize_location_name(loc.name) in fallback_keys:
+                return loc
+            for alt in loc.alternate_names:
+                if _normalize_location_name(alt.alternate_name) in fallback_keys:
+                    return loc
+
+    # No match — create a new Location and enqueue geocoding.
+    new_loc = Location(name=location_name, emoji=_DEFAULT_LOCATION_EMOJI)
+    db.add(new_loc)
+    await db.flush()
+    geocode_location.delay(new_loc.id)
+    return new_loc

--- a/backend/tests/services/test_event_processing.py
+++ b/backend/tests/services/test_event_processing.py
@@ -1,9 +1,23 @@
-"""Tests for pure event-processing helpers."""
+"""Tests for event-processing helpers (pure + async DB services)."""
 
+from unittest.mock import MagicMock, patch
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from api.models.base import TagRuleType
+from api.models.location import Location, LocationAlternateName
+from api.models.tag import TagRule
 from api.services.event_processing import (
     BLOCKED_EMOJI,
+    TagRules,
     extract_emoji,
     generate_short_name,
+    load_tag_rules,
+    process_tags,
+    resolve_location,
+    should_skip_for_tags,
 )
 
 
@@ -41,3 +55,175 @@ def test_extract_emoji_skips_blocked_emoji_and_finds_next() -> None:
     emoji, stripped = extract_emoji(text)
     assert emoji == "\U0001f3a8"
     assert stripped == "Art Show"
+
+
+@pytest.mark.asyncio
+class TestResolveLocation:
+    async def test_exact_name_match(self, db_session: AsyncSession) -> None:
+        existing = Location(name="Museum of Modern Art", emoji="\U0001f3a8")
+        db_session.add(existing)
+        await db_session.flush()
+
+        with patch("api.services.event_processing.geocode_location") as mock_task:
+            result = await resolve_location(
+                db_session,
+                location_name="Museum of Modern Art",
+                sublocation=None,
+                source_site_name="site",
+                event_name="Some Event",
+            )
+
+        assert result is not None
+        assert result.id == existing.id
+        mock_task.delay.assert_not_called()
+
+    async def test_alternate_name_match(self, db_session: AsyncSession) -> None:
+        loc = Location(name="Museum of Modern Art", emoji="\U0001f3a8")
+        loc.alternate_names = [LocationAlternateName(alternate_name="MoMA")]
+        db_session.add(loc)
+        await db_session.flush()
+
+        with patch("api.services.event_processing.geocode_location") as mock_task:
+            result = await resolve_location(
+                db_session,
+                location_name="MoMA",
+                sublocation=None,
+                source_site_name="site",
+                event_name="Show",
+            )
+
+        assert result is not None
+        assert result.id == loc.id
+        mock_task.delay.assert_not_called()
+
+    async def test_fuzzy_match_above_threshold(self, db_session: AsyncSession) -> None:
+        loc = Location(name="Museum of Modern Art", emoji="\U0001f3a8")
+        db_session.add(loc)
+        await db_session.flush()
+
+        with patch("api.services.event_processing.geocode_location") as mock_task:
+            result = await resolve_location(
+                db_session,
+                location_name="Museum of Moderne Art",
+                sublocation=None,
+                source_site_name="site",
+                event_name="Show",
+            )
+
+        assert result is not None
+        assert result.id == loc.id
+        mock_task.delay.assert_not_called()
+
+    async def test_unknown_creates_and_enqueues_geocode(
+        self, db_session: AsyncSession
+    ) -> None:
+        with patch(
+            "api.services.event_processing.geocode_location", new=MagicMock()
+        ) as mock_task:
+            result = await resolve_location(
+                db_session,
+                location_name="Totally Unique Venue 42",
+                sublocation=None,
+                source_site_name="some-source",
+                event_name="Mystery Event",
+            )
+
+        assert result is not None
+        assert result.id is not None
+        assert result.name == "Totally Unique Venue 42"
+        assert result.emoji == "\U0001f3ad"
+        mock_task.delay.assert_called_once_with(result.id)
+
+        fetched = await db_session.get(Location, result.id)
+        assert fetched is not None
+        assert fetched.name == "Totally Unique Venue 42"
+
+    async def test_none_location_name_returns_none(
+        self, db_session: AsyncSession
+    ) -> None:
+        with patch("api.services.event_processing.geocode_location") as mock_task:
+            result = await resolve_location(
+                db_session,
+                location_name=None,
+                sublocation=None,
+                source_site_name="site",
+                event_name="Show",
+            )
+
+        assert result is None
+        mock_task.delay.assert_not_called()
+
+
+@pytest.mark.asyncio
+class TestProcessTags:
+    async def _cleanup_rules(self, db_session: AsyncSession) -> None:
+        """Remove any pre-existing TagRule rows so each test is isolated."""
+        rows = (await db_session.execute(select(TagRule))).scalars().all()
+        for row in rows:
+            await db_session.delete(row)
+        await db_session.flush()
+
+    async def test_rewrite_transforms(self, db_session: AsyncSession) -> None:
+        await self._cleanup_rules(db_session)
+        db_session.add(
+            TagRule(
+                rule_type=TagRuleType.rewrite,
+                pattern="livemusic",
+                replacement="Live Music",
+            )
+        )
+        await db_session.flush()
+
+        rules = await load_tag_rules(db_session)
+        result = await process_tags(["LiveMusic"], rules)
+
+        assert result == ["Live Music"]
+
+    async def test_exclude_drops(self, db_session: AsyncSession) -> None:
+        await self._cleanup_rules(db_session)
+        db_session.add(
+            TagRule(
+                rule_type=TagRuleType.exclude,
+                pattern="spam",
+                replacement=None,
+            )
+        )
+        await db_session.flush()
+
+        rules = await load_tag_rules(db_session)
+        result = await process_tags(["Spam", "Art"], rules)
+
+        assert result == ["Art"]
+
+    async def test_extra_tags_appended_and_deduped(
+        self, db_session: AsyncSession
+    ) -> None:
+        await self._cleanup_rules(db_session)
+        rules = await load_tag_rules(db_session)
+
+        result = await process_tags(["Art"], rules, extra_tags=["art"])
+
+        assert len(result) == 1
+        assert result[0].lower() == "art"
+
+    async def test_should_skip_for_tags_removal(self, db_session: AsyncSession) -> None:
+        await self._cleanup_rules(db_session)
+        db_session.add(
+            TagRule(
+                rule_type=TagRuleType.remove,
+                pattern="nsfw",
+                replacement=None,
+            )
+        )
+        await db_session.flush()
+
+        rules = await load_tag_rules(db_session)
+        assert should_skip_for_tags(["NSFW", "Art"], rules) is True
+
+    async def test_should_skip_for_tags_false(self, db_session: AsyncSession) -> None:
+        await self._cleanup_rules(db_session)
+        rules = await load_tag_rules(db_session)
+
+        assert should_skip_for_tags(["Art", "Music"], rules) is False
+        empty_rules = TagRules(rewrites={}, excludes=frozenset(), removals=frozenset())
+        assert should_skip_for_tags(["nsfw"], empty_rules) is False

--- a/backend/tests/services/test_event_processing.py
+++ b/backend/tests/services/test_event_processing.py
@@ -57,173 +57,190 @@ def test_extract_emoji_skips_blocked_emoji_and_finds_next() -> None:
     assert stripped == "Art Show"
 
 
-@pytest.mark.asyncio
-class TestResolveLocation:
-    async def test_exact_name_match(self, db_session: AsyncSession) -> None:
-        existing = Location(name="Museum of Modern Art", emoji="\U0001f3a8")
-        db_session.add(existing)
-        await db_session.flush()
-
-        with patch("api.services.event_processing.geocode_location") as mock_task:
-            result = await resolve_location(
-                db_session,
-                location_name="Museum of Modern Art",
-                sublocation=None,
-                source_site_name="site",
-                event_name="Some Event",
-            )
-
-        assert result is not None
-        assert result.id == existing.id
-        mock_task.delay.assert_not_called()
-
-    async def test_alternate_name_match(self, db_session: AsyncSession) -> None:
-        loc = Location(name="Museum of Modern Art", emoji="\U0001f3a8")
-        loc.alternate_names = [LocationAlternateName(alternate_name="MoMA")]
-        db_session.add(loc)
-        await db_session.flush()
-
-        with patch("api.services.event_processing.geocode_location") as mock_task:
-            result = await resolve_location(
-                db_session,
-                location_name="MoMA",
-                sublocation=None,
-                source_site_name="site",
-                event_name="Show",
-            )
-
-        assert result is not None
-        assert result.id == loc.id
-        mock_task.delay.assert_not_called()
-
-    async def test_fuzzy_match_above_threshold(self, db_session: AsyncSession) -> None:
-        loc = Location(name="Museum of Modern Art", emoji="\U0001f3a8")
-        db_session.add(loc)
-        await db_session.flush()
-
-        with patch("api.services.event_processing.geocode_location") as mock_task:
-            result = await resolve_location(
-                db_session,
-                location_name="Museum of Moderne Art",
-                sublocation=None,
-                source_site_name="site",
-                event_name="Show",
-            )
-
-        assert result is not None
-        assert result.id == loc.id
-        mock_task.delay.assert_not_called()
-
-    async def test_unknown_creates_and_enqueues_geocode(
-        self, db_session: AsyncSession
-    ) -> None:
-        with patch(
-            "api.services.event_processing.geocode_location", new=MagicMock()
-        ) as mock_task:
-            result = await resolve_location(
-                db_session,
-                location_name="Totally Unique Venue 42",
-                sublocation=None,
-                source_site_name="some-source",
-                event_name="Mystery Event",
-            )
-
-        assert result is not None
-        assert result.id is not None
-        assert result.name == "Totally Unique Venue 42"
-        assert result.emoji == "\U0001f3ad"
-        mock_task.delay.assert_called_once_with(result.id)
-
-        fetched = await db_session.get(Location, result.id)
-        assert fetched is not None
-        assert fetched.name == "Totally Unique Venue 42"
-
-    async def test_none_location_name_returns_none(
-        self, db_session: AsyncSession
-    ) -> None:
-        with patch("api.services.event_processing.geocode_location") as mock_task:
-            result = await resolve_location(
-                db_session,
-                location_name=None,
-                sublocation=None,
-                source_site_name="site",
-                event_name="Show",
-            )
-
-        assert result is None
-        mock_task.delay.assert_not_called()
+async def _cleanup_tag_rules(db_session: AsyncSession) -> None:
+    """Remove any pre-existing TagRule rows so each test is isolated."""
+    rows = (await db_session.execute(select(TagRule))).scalars().all()
+    for row in rows:
+        await db_session.delete(row)
+    await db_session.flush()
 
 
 @pytest.mark.asyncio
-class TestProcessTags:
-    async def _cleanup_rules(self, db_session: AsyncSession) -> None:
-        """Remove any pre-existing TagRule rows so each test is isolated."""
-        rows = (await db_session.execute(select(TagRule))).scalars().all()
-        for row in rows:
-            await db_session.delete(row)
-        await db_session.flush()
+async def test_resolve_location_exact_name_match(db_session: AsyncSession) -> None:
+    existing = Location(name="Museum of Modern Art", emoji="\U0001f3a8")
+    db_session.add(existing)
+    await db_session.flush()
 
-    async def test_rewrite_transforms(self, db_session: AsyncSession) -> None:
-        await self._cleanup_rules(db_session)
-        db_session.add(
-            TagRule(
-                rule_type=TagRuleType.rewrite,
-                pattern="livemusic",
-                replacement="Live Music",
-            )
+    with patch("api.services.event_processing.geocode_location") as mock_task:
+        result = await resolve_location(
+            db_session,
+            location_name="Museum of Modern Art",
+            sublocation=None,
+            source_site_name="site",
+            event_name="Some Event",
         )
-        await db_session.flush()
 
-        rules = await load_tag_rules(db_session)
-        result = await process_tags(["LiveMusic"], rules)
+    assert result is not None
+    assert result.id == existing.id
+    mock_task.delay.assert_not_called()
 
-        assert result == ["Live Music"]
 
-    async def test_exclude_drops(self, db_session: AsyncSession) -> None:
-        await self._cleanup_rules(db_session)
-        db_session.add(
-            TagRule(
-                rule_type=TagRuleType.exclude,
-                pattern="spam",
-                replacement=None,
-            )
+@pytest.mark.asyncio
+async def test_resolve_location_alternate_name_match(db_session: AsyncSession) -> None:
+    loc = Location(name="Museum of Modern Art", emoji="\U0001f3a8")
+    loc.alternate_names = [LocationAlternateName(alternate_name="MoMA")]
+    db_session.add(loc)
+    await db_session.flush()
+
+    with patch("api.services.event_processing.geocode_location") as mock_task:
+        result = await resolve_location(
+            db_session,
+            location_name="MoMA",
+            sublocation=None,
+            source_site_name="site",
+            event_name="Show",
         )
-        await db_session.flush()
 
-        rules = await load_tag_rules(db_session)
-        result = await process_tags(["Spam", "Art"], rules)
+    assert result is not None
+    assert result.id == loc.id
+    mock_task.delay.assert_not_called()
 
-        assert result == ["Art"]
 
-    async def test_extra_tags_appended_and_deduped(
-        self, db_session: AsyncSession
-    ) -> None:
-        await self._cleanup_rules(db_session)
-        rules = await load_tag_rules(db_session)
+@pytest.mark.asyncio
+async def test_resolve_location_fuzzy_match_above_threshold(
+    db_session: AsyncSession,
+) -> None:
+    loc = Location(name="Museum of Modern Art", emoji="\U0001f3a8")
+    db_session.add(loc)
+    await db_session.flush()
 
-        result = await process_tags(["Art"], rules, extra_tags=["art"])
-
-        assert len(result) == 1
-        assert result[0].lower() == "art"
-
-    async def test_should_skip_for_tags_removal(self, db_session: AsyncSession) -> None:
-        await self._cleanup_rules(db_session)
-        db_session.add(
-            TagRule(
-                rule_type=TagRuleType.remove,
-                pattern="nsfw",
-                replacement=None,
-            )
+    with patch("api.services.event_processing.geocode_location") as mock_task:
+        result = await resolve_location(
+            db_session,
+            location_name="Museum of Moderne Art",
+            sublocation=None,
+            source_site_name="site",
+            event_name="Show",
         )
-        await db_session.flush()
 
-        rules = await load_tag_rules(db_session)
-        assert should_skip_for_tags(["NSFW", "Art"], rules) is True
+    assert result is not None
+    assert result.id == loc.id
+    mock_task.delay.assert_not_called()
 
-    async def test_should_skip_for_tags_false(self, db_session: AsyncSession) -> None:
-        await self._cleanup_rules(db_session)
-        rules = await load_tag_rules(db_session)
 
-        assert should_skip_for_tags(["Art", "Music"], rules) is False
-        empty_rules = TagRules(rewrites={}, excludes=frozenset(), removals=frozenset())
-        assert should_skip_for_tags(["nsfw"], empty_rules) is False
+@pytest.mark.asyncio
+async def test_resolve_location_unknown_creates_and_enqueues_geocode(
+    db_session: AsyncSession,
+) -> None:
+    with patch(
+        "api.services.event_processing.geocode_location", new=MagicMock()
+    ) as mock_task:
+        result = await resolve_location(
+            db_session,
+            location_name="Totally Unique Venue 42",
+            sublocation=None,
+            source_site_name="some-source",
+            event_name="Mystery Event",
+        )
+
+    assert result is not None
+    assert result.id is not None
+    assert result.name == "Totally Unique Venue 42"
+    assert result.emoji == "\U0001f3ad"
+    mock_task.delay.assert_called_once_with(result.id)
+
+    fetched = await db_session.get(Location, result.id)
+    assert fetched is not None
+    assert fetched.name == "Totally Unique Venue 42"
+
+
+@pytest.mark.asyncio
+async def test_resolve_location_none_location_name_returns_none(
+    db_session: AsyncSession,
+) -> None:
+    with patch("api.services.event_processing.geocode_location") as mock_task:
+        result = await resolve_location(
+            db_session,
+            location_name=None,
+            sublocation=None,
+            source_site_name="site",
+            event_name="Show",
+        )
+
+    assert result is None
+    mock_task.delay.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_process_tags_rewrite_transforms(db_session: AsyncSession) -> None:
+    await _cleanup_tag_rules(db_session)
+    db_session.add(
+        TagRule(
+            rule_type=TagRuleType.rewrite,
+            pattern="livemusic",
+            replacement="Live Music",
+        )
+    )
+    await db_session.flush()
+
+    rules = await load_tag_rules(db_session)
+    result = await process_tags(["LiveMusic"], rules)
+
+    assert result == ["Live Music"]
+
+
+@pytest.mark.asyncio
+async def test_process_tags_exclude_drops(db_session: AsyncSession) -> None:
+    await _cleanup_tag_rules(db_session)
+    db_session.add(
+        TagRule(
+            rule_type=TagRuleType.exclude,
+            pattern="spam",
+            replacement=None,
+        )
+    )
+    await db_session.flush()
+
+    rules = await load_tag_rules(db_session)
+    result = await process_tags(["Spam", "Art"], rules)
+
+    assert result == ["Art"]
+
+
+@pytest.mark.asyncio
+async def test_process_tags_extra_tags_appended_and_deduped(
+    db_session: AsyncSession,
+) -> None:
+    await _cleanup_tag_rules(db_session)
+    rules = await load_tag_rules(db_session)
+
+    result = await process_tags(["Art"], rules, extra_tags=["art"])
+
+    assert len(result) == 1
+    assert result[0].lower() == "art"
+
+
+@pytest.mark.asyncio
+async def test_should_skip_for_tags_removal(db_session: AsyncSession) -> None:
+    await _cleanup_tag_rules(db_session)
+    db_session.add(
+        TagRule(
+            rule_type=TagRuleType.remove,
+            pattern="nsfw",
+            replacement=None,
+        )
+    )
+    await db_session.flush()
+
+    rules = await load_tag_rules(db_session)
+    assert should_skip_for_tags(["NSFW", "Art"], rules) is True
+
+
+@pytest.mark.asyncio
+async def test_should_skip_for_tags_false(db_session: AsyncSession) -> None:
+    await _cleanup_tag_rules(db_session)
+    rules = await load_tag_rules(db_session)
+
+    assert should_skip_for_tags(["Art", "Music"], rules) is False
+    empty_rules = TagRules(rewrites={}, excludes=frozenset(), removals=frozenset())
+    assert should_skip_for_tags(["nsfw"], empty_rules) is False


### PR DESCRIPTION
## What
Builds on PR #124 by adding the async DB-touching services (`resolve_location`, `load_tag_rules`, `process_tags`, `should_skip_for_tags`) and the private location normalization helpers to `backend/api/services/event_processing.py`, plus the async DB test classes in `backend/tests/services/test_event_processing.py`. Uses `difflib.SequenceMatcher` (no Levenshtein dependency) and enqueues `geocode_location.delay` on new Location creation.

## Why
Part of issue #110 — Phase 3 of the scraper/backend separation (OpenSpec `separate-scraper-backend-celery`). Phases 1 & 2 are already merged. This PR completes the port of pure event-processing logic from `pipeline/processor.py` to async SQLAlchemy services so the Celery consumer can resolve locations and apply tag rules directly against the backend's async session without reaching into the legacy psycopg2 pipeline.

## How
- Extends `backend/api/services/event_processing.py` (created in PR #124) with async DB helpers and the private normalization utilities.
- Adds a frozen `TagRules` dataclass (rewrites/excludes/removals) and `load_tag_rules` to hydrate it from `TagRule` rows.
- Ports the location name + street address normalizers (`_normalize_location_name`, `_normalize_street_address`) from `pipeline/processor.py`.
- `resolve_location` preloads all locations in a single query with `selectinload(Location.alternate_names)`, then tries exact name match → alternate-name match → fuzzy match via `SequenceMatcher` ratio ≥ 0.85. On no match, creates a new `Location`, `await db.flush()` to obtain the id, and enqueues `geocode_location.delay(loc.id)`. Does not commit — the caller owns the transaction.
- `process_tags` normalizes, applies rewrites, drops excludes, appends extra tags, and dedupes while preserving order. `should_skip_for_tags` returns `True` iff any normalized tag is in `rules.removals`.
- Appends async DB test classes to `backend/tests/services/test_event_processing.py` using the shared `db_session` fixture. Patches `backend.api.services.event_processing.geocode_location` with `MagicMock` so `.delay` never hits the broker.

## Changes
- `backend/api/services/event_processing.py`: adds `TagRules` dataclass, `_normalize_location_name`, `_normalize_street_address`, `load_tag_rules`, `process_tags`, `should_skip_for_tags`, and `resolve_location`. Adds SQLAlchemy / model / task imports.
- `backend/tests/services/test_event_processing.py`: appends `TestResolveLocation` (exact/alt-name/fuzzy/unknown/None cases + geocode enqueue assertion) and `TestProcessTags` (rewrite/exclude/extra-tags-dedupe/skip-for-removal cases) using `db_session` + patched `geocode_location`.

## Validation
- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run --project backend pytest backend/tests/services/test_event_processing.py -v`
- [x] `uv run --project backend pytest backend/tests/services -v`
- [x] `uv run --project backend mypy backend/api/services/event_processing.py`

## Stack
PR 2/2 for: Phase 3 of issue #110 — port pure event-processing logic from `pipeline/processor.py` to async SQLAlchemy services in the backend so the Celery consumer can process `ExtractedEvent` rows without calling into the old pipeline.

Stacked on top of #124 (base branch: `ship/event-processing-helpers`).

Refs #110
