### PR TITLE
feat: Name normalization and stemming helpers

### DIFF
--- a/backend/api/services/event_merging.py
+++ b/backend/api/services/event_merging.py
@@ -1,0 +1,98 @@
+"""Event deduplication and merging helpers.
+
+Pure helpers ported verbatim from ``pipeline/merger.py`` lines 17-87
+(name normalization, stemming, and significant-word extraction).
+
+This module intentionally has no database access; it only exposes pure
+functions used by the event-merging service. See ``pipeline/merger.py``
+for the original reference implementation.
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+
+STOP_WORDS: frozenset[str] = frozenset(
+    {"the", "and", "for", "with", "from", "into", "your"}
+)
+
+SEMANTIC_EQUIVALENTS: dict[str, str] = {
+    "dinner": "dine",
+    "dining": "dine",
+    "diner": "dine",
+    # Day abbreviations -> full names
+    "mon": "monday",
+    "tue": "tuesday",
+    "tues": "tuesday",
+    "wed": "wednesday",
+    "weds": "wednesday",
+    "thu": "thursday",
+    "thur": "thursday",
+    "thurs": "thursday",
+    "fri": "friday",
+    "sat": "saturday",
+    "sun": "sunday",
+}
+
+STEM_SUFFIXES: list[tuple[str, str]] = [
+    ("ency", "enc"),  # residency -> residenc
+    ("ence", "enc"),  # residence -> residenc
+    ("ing", ""),  # running -> runn
+    ("tion", "t"),  # creation -> creat
+    ("sion", "s"),  # decision -> decis
+    ("ies", "y"),  # stories -> story
+    ("es", ""),  # boxes -> box
+    ("s", ""),  # cats -> cat
+]
+
+
+def normalize_name_for_dedup(name: str) -> str:
+    """Remove accents, punctuation, underscores, and extra whitespace.
+
+    Returns a lowercase, whitespace-collapsed string suitable for
+    deduplication comparisons.
+    """
+    # Normalize unicode to remove accents (é -> e, etc.)
+    nfkd = unicodedata.normalize("NFKD", name)
+    ascii_name = "".join(c for c in nfkd if not unicodedata.combining(c))
+
+    no_underscores = ascii_name.replace("_", "")
+    # Replace punctuation with spaces (not just remove) to avoid word
+    # concatenation, e.g. "Alice/Bob" -> "Alice Bob", not "AliceBob".
+    no_punct = re.sub(r"[^\w\s]", " ", no_underscores.strip().lower())
+    normalized = re.sub(r"\s+", " ", no_punct).strip()
+    return normalized
+
+
+def stem_word(word: str) -> str:
+    """Apply semantic equivalents then a small set of suffix rules."""
+    if word in SEMANTIC_EQUIVALENTS:
+        return SEMANTIC_EQUIVALENTS[word]
+
+    for suffix, replacement in STEM_SUFFIXES:
+        if word.endswith(suffix) and len(word) > len(suffix) + 2:
+            return word[: -len(suffix)] + replacement
+    return word
+
+
+def _is_year(word: str) -> bool:
+    """Return True if ``word`` is a 4-digit year in the 20XX range."""
+    return len(word) == 4 and word.isdigit() and word.startswith("20")
+
+
+def get_significant_words(name: str, *, stem: bool = False) -> frozenset[str]:
+    """Return 3+ char words from ``name`` minus stop words and years.
+
+    When ``stem`` is true, each word is passed through :func:`stem_word`
+    before being returned.
+    """
+    norm = normalize_name_for_dedup(name)
+    words = norm.split()
+
+    result = {
+        w for w in words if len(w) >= 3 and w not in STOP_WORDS and not _is_year(w)
+    }
+    if stem:
+        result = {stem_word(w) for w in result}
+    return frozenset(result)

--- a/backend/tests/services/test_event_merging_normalization.py
+++ b/backend/tests/services/test_event_merging_normalization.py
@@ -1,0 +1,67 @@
+"""Tests for name normalization helpers in ``event_merging``."""
+
+from api.services.event_merging import (
+    get_significant_words,
+    normalize_name_for_dedup,
+    stem_word,
+)
+
+
+def test_normalize_name_for_dedup_strips_accents() -> None:
+    assert normalize_name_for_dedup("café") == "cafe"
+    assert normalize_name_for_dedup("Café Noël") == "cafe noel"
+
+
+def test_normalize_name_for_dedup_replaces_punctuation_with_space() -> None:
+    assert normalize_name_for_dedup("Alice/Bob") == "alice bob"
+
+
+def test_normalize_name_for_dedup_collapses_whitespace() -> None:
+    assert normalize_name_for_dedup("  Hello   world  ") == "hello world"
+    assert normalize_name_for_dedup("foo___bar") == "foobar"
+    assert normalize_name_for_dedup("foo\t\nbar") == "foo bar"
+
+
+def test_stem_word_semantic_equivalents() -> None:
+    assert stem_word("dinner") == "dine"
+    assert stem_word("dining") == "dine"
+    assert stem_word("diner") == "dine"
+    assert stem_word("tues") == "tuesday"
+    assert stem_word("fri") == "friday"
+
+
+def test_stem_word_suffix_rules() -> None:
+    assert stem_word("residency") == "residenc"
+    assert stem_word("residence") == "residenc"
+    assert stem_word("stories") == "story"
+    assert stem_word("boxes") == "box"
+    assert stem_word("creation") == "creat"
+    assert stem_word("decision") == "decis"
+
+
+def test_stem_word_short_word_unchanged() -> None:
+    assert stem_word("cat") == "cat"
+    # Guard: len(word) > len(suffix) + 2, so short words stay put.
+    # For suffix "s" (len 1), word must be longer than 3, so "is" and "as"
+    # are unchanged. Similarly "running" (len 7) > 3+2 so the "ing" rule
+    # fires, but shorter "ing" words like "sing" stay as "sing".
+    assert stem_word("is") == "is"
+    assert stem_word("as") == "as"
+    assert stem_word("sing") == "sing"
+    assert stem_word("boxes") == "box"  # boundary for "es" (len 5 > 4)
+
+
+def test_get_significant_words_drops_stop_words_and_years() -> None:
+    assert get_significant_words("The 2025 Jazz Festival") == frozenset(
+        {"jazz", "festival"}
+    )
+    # Stop words and <3 char words are dropped.
+    assert get_significant_words("a and the for") == frozenset()
+
+
+def test_get_significant_words_stemmed() -> None:
+    assert get_significant_words("Dinner Stories", stem=True) == frozenset(
+        {"dine", "story"}
+    )
+    # Without stem, raw words are retained.
+    assert get_significant_words("Dinner Stories") == frozenset({"dinner", "stories"})


### PR DESCRIPTION
## What
Create the foundation of the merging service: unicode-normalized name handling, semantic stemming, and significant-word extraction. Pure functions, no DB access, verbatim port of `pipeline/merger.py:17-87`.

## Why
This is the first building block of the event-merging service being ported from `pipeline/merger.py` into the backend as an async SQLAlchemy service at `backend/api/services/event_merging.py`. Accurate name normalization and stemming underpin all downstream duplicate detection logic.

## How
- Add `STOP_WORDS`, `SEMANTIC_EQUIVALENTS`, and `STEM_SUFFIXES` module-level constants
- Implement `normalize_name_for_dedup`: NFKD unicode, drop combining marks/underscores, replace punctuation with space, lowercase, collapse whitespace
- Implement `stem_word`: apply semantic equivalents first, then walk `STEM_SUFFIXES` with a length guard
- Implement `_is_year` and `get_significant_words`: returns frozenset of 3+ char words, minus stop words and years, optionally stemmed

## Changes
- `backend/api/services/event_merging.py`: New module — constants, `normalize_name_for_dedup`, `stem_word`, `_is_year`, `get_significant_words`
- `backend/tests/services/test_event_merging_normalization.py`: Eight test functions covering accent stripping, punctuation replacement, whitespace collapsing, semantic equivalents, suffix rules, short-word guard, stop-word/year filtering, and stemmed output

## Validation
- [x] `cd backend && uv run ruff check .`
- [x] `cd backend && uv run ruff format --check .`
- [x] `cd backend && uv run mypy api/services/event_merging.py`
- [x] `cd backend && uv run pytest tests/services/test_event_merging_normalization.py -v`

## Stack
PR 1/8 for: Port event-merging service (Issue #111)
