### PR TITLE
feat: Prefix stripping and core title extraction

### DIFF
--- a/backend/api/services/event_merging.py
+++ b/backend/api/services/event_merging.py
@@ -96,3 +96,60 @@ def get_significant_words(name: str, *, stem: bool = False) -> frozenset[str]:
     if stem:
         result = {stem_word(w) for w in result}
     return frozenset(result)
+
+
+KNOWN_PROGRAM_PREFIXES: tuple[str, ...] = ("FIDO",)
+
+PRESENTER_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(r"^.+?\s+presents?\s*:?\s*", re.IGNORECASE),
+    re.compile(r"^.+?\s+productions?\s*:?\s*", re.IGNORECASE),
+    re.compile(r"^hosted\s+by\s+.+?:\s*", re.IGNORECASE),
+)
+
+_BRACKETED_PREFIX_RE = re.compile(r"^\s*\[[^\]]+\]\s*")
+
+
+def strip_common_prefixes(name: str) -> str:
+    """Strip common prefixes that don't change event identity.
+
+    Handles:
+    - Bracketed prefixes: ``[member-only]``, ``[free]``, ``[virtual]``, etc.
+    - Known event program prefixes: ``FIDO`` (Prospect Park dog events), etc.
+
+    Examples:
+        ``"[member-only] Sewing Machines"`` -> ``"Sewing Machines"``
+        ``"FIDO Coffee Bark"`` -> ``"Coffee Bark"``
+        ``"[FREE] Jazz in the Park"`` -> ``"Jazz in the Park"``
+    """
+    result = name.strip()
+    result = _BRACKETED_PREFIX_RE.sub("", result)
+
+    for prefix in KNOWN_PROGRAM_PREFIXES:
+        pattern = rf"^{re.escape(prefix)}\s+"
+        result = re.sub(pattern, "", result, flags=re.IGNORECASE)
+
+    return result.strip()
+
+
+def extract_core_title(name: str) -> str:
+    """Extract the core title by removing presenter prefixes and subtitles.
+
+    Examples:
+        ``"Manhattan Theatre Club Presents The Monsters"`` -> ``"The Monsters"``
+        ``"The Monsters: a Sibling Love Story"`` -> ``"The Monsters"``
+        ``"Lincoln Center Presents: Jazz at Midnight"`` -> ``"Jazz at Midnight"``
+        ``"[member-only] Sewing Class"`` -> ``"Sewing Class"``
+        ``"FIDO Coffee Bark"`` -> ``"Coffee Bark"``
+    """
+    result = strip_common_prefixes(name)
+
+    for pattern in PRESENTER_PATTERNS:
+        result = pattern.sub("", result)
+
+    # Remove subtitles after colon, but keep if main title is too short.
+    if ":" in result:
+        main_title = result.split(":", 1)[0].strip()
+        if len(main_title) >= 5:
+            result = main_title
+
+    return result.strip()

--- a/backend/tests/services/test_event_merging_titles.py
+++ b/backend/tests/services/test_event_merging_titles.py
@@ -1,0 +1,46 @@
+"""Tests for prefix stripping and core title extraction in ``event_merging``."""
+
+from api.services.event_merging import (
+    extract_core_title,
+    strip_common_prefixes,
+)
+
+
+def test_strip_common_prefixes_bracketed() -> None:
+    assert strip_common_prefixes("[member-only] Sewing") == "Sewing"
+    assert strip_common_prefixes("[member-only] Sewing Machines") == "Sewing Machines"
+
+
+def test_strip_common_prefixes_fido() -> None:
+    assert strip_common_prefixes("FIDO Coffee Bark") == "Coffee Bark"
+    # Case-insensitive match on the known prefix.
+    assert strip_common_prefixes("fido Coffee Bark") == "Coffee Bark"
+
+
+def test_strip_common_prefixes_nested() -> None:
+    assert strip_common_prefixes("[FREE] Jazz") == "Jazz"
+    assert strip_common_prefixes("[FREE] Jazz in the Park") == "Jazz in the Park"
+
+
+def test_extract_core_title_presenter() -> None:
+    assert (
+        extract_core_title("Manhattan Theatre Club Presents The Monsters")
+        == "The Monsters"
+    )
+    assert (
+        extract_core_title("Lincoln Center Presents: Jazz at Midnight")
+        == "Jazz at Midnight"
+    )
+
+
+def test_extract_core_title_subtitle() -> None:
+    assert extract_core_title("The Monsters: a Sibling Love Story") == "The Monsters"
+
+
+def test_extract_core_title_short_main_keeps_subtitle() -> None:
+    # Main title "ABC" is under 5 chars, so the subtitle is kept.
+    assert extract_core_title("ABC: Long Title Here") == "ABC: Long Title Here"
+
+
+def test_extract_core_title_hosted_by() -> None:
+    assert extract_core_title("Hosted by Jane: Talk") == "Talk"


### PR DESCRIPTION
## What
Add the title-normalization layer on top of PR 1: strip bracketed/program prefixes and extract core titles by removing presenter prefixes and subtitles. Pure functions, port of `pipeline/merger.py:90-154`.

## Why
Before comparing event names for deduplication, bracketed tags like `[FREE]`, known program prefixes like `FIDO`, and presenter phrases like "Manhattan Theatre Club Presents" must be stripped so the core title can be compared. This layer sits directly on top of the name normalization helpers from PR 1.

## How
- Add `KNOWN_PROGRAM_PREFIXES`, `PRESENTER_PATTERNS` (compiled regex), and `_BRACKETED_PREFIX_RE`
- Implement `strip_common_prefixes`: strip bracketed prefix, then case-insensitive known-prefix removal
- Implement `extract_core_title`: call `strip_common_prefixes`, apply presenter patterns, then strip subtitle if main title is >= 5 chars

## Changes
- `backend/api/services/event_merging.py`: Append `KNOWN_PROGRAM_PREFIXES`, `PRESENTER_PATTERNS`, `_BRACKETED_PREFIX_RE`, `strip_common_prefixes`, `extract_core_title`
- `backend/tests/services/test_event_merging_titles.py`: Seven test functions covering bracketed prefix, FIDO prefix, nested prefix, presenter pattern, subtitle stripping, short-main-title preservation, and hosted-by pattern

## Validation
- [x] `cd backend && uv run ruff check .`
- [x] `cd backend && uv run ruff format --check .`
- [x] `cd backend && uv run mypy api/services/event_merging.py`
- [x] `cd backend && uv run pytest tests/services/test_event_merging_titles.py -v`

## Stack
PR 2/8 for: Port event-merging service (Issue #111)
