### PR TITLE
feat: Occurrence and tag JSONB parsing

### DIFF
--- a/backend/api/services/event_merging.py
+++ b/backend/api/services/event_merging.py
@@ -10,8 +10,12 @@ for the original reference implementation.
 
 from __future__ import annotations
 
+import json
 import re
 import unicodedata
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta
+from typing import Any
 
 STOP_WORDS: frozenset[str] = frozenset(
     {"the", "and", "for", "with", "from", "into", "your"}
@@ -367,3 +371,119 @@ def are_names_similar(name1: str, name2: str) -> bool:
             return True
 
     return False
+
+
+# ---------------------------------------------------------------------------
+# JSONB parsing helpers (ported from pipeline/merger.py lines 364-375, 563-610)
+# ---------------------------------------------------------------------------
+
+FUTURE_LIMIT_DAYS: int = 90
+ARCHIVE_GRACE_DAYS: int = 14
+
+
+@dataclass(frozen=True)
+class ParsedOccurrence:
+    """A single parsed occurrence from the JSONB ``occurrences`` column."""
+
+    start_date: date
+    start_time: str | None
+    end_date: date | None
+    end_time: str | None
+
+
+def _parse_jsonb(value: object) -> list[Any] | dict[str, Any] | None:
+    """Parse a JSONB value that may be a string, dict/list, or None.
+
+    Ported from ``pipeline/merger.py`` lines 364-375.
+    """
+    if value is None:
+        return None
+    if isinstance(value, (dict, list)):
+        return value
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+        except (TypeError, ValueError):
+            return None
+        if isinstance(parsed, (dict, list)):
+            return parsed
+        return None
+    return None
+
+
+def _parse_date(value: object) -> date | None:
+    """Safely parse a YYYY-MM-DD string into a date, or None."""
+    if not value:
+        return None
+    try:
+        return datetime.strptime(str(value), "%Y-%m-%d").date()
+    except (TypeError, ValueError):
+        return None
+
+
+def _parse_time_str(value: object) -> str | None:
+    """Return the value as a string if non-empty, else None."""
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        return None
+    stripped = value.strip()
+    return stripped or None
+
+
+def parse_occurrences(raw: object, *, today: date) -> list[ParsedOccurrence]:
+    """Parse and filter the JSONB ``occurrences`` column.
+
+    Keeps only occurrences whose ``start_date`` falls within
+    ``[today, today + FUTURE_LIMIT_DAYS]``. Malformed entries are skipped.
+
+    Ported from ``pipeline/merger.py`` lines 563-605.
+    """
+    parsed = _parse_jsonb(raw) or []
+    if not isinstance(parsed, list):
+        return []
+
+    future_limit = today + timedelta(days=FUTURE_LIMIT_DAYS)
+    result: list[ParsedOccurrence] = []
+
+    for occ in parsed:
+        if not isinstance(occ, dict):
+            continue
+        start_date = _parse_date(occ.get("start_date"))
+        if start_date is None:
+            continue
+        if not (today <= start_date <= future_limit):
+            continue
+
+        result.append(
+            ParsedOccurrence(
+                start_date=start_date,
+                start_time=_parse_time_str(occ.get("start_time")),
+                end_date=_parse_date(occ.get("end_date")),
+                end_time=_parse_time_str(occ.get("end_time")),
+            )
+        )
+
+    return result
+
+
+def parse_tags(raw: object) -> list[str]:
+    """Parse the JSONB ``tags`` column into a clean list of strings.
+
+    Drops non-string entries and strips whitespace from each tag. Empty
+    strings (after stripping) are also dropped.
+
+    Ported from ``pipeline/merger.py`` lines 607-610.
+    """
+    parsed = _parse_jsonb(raw) or []
+    if not isinstance(parsed, list):
+        return []
+
+    result: list[str] = []
+    for tag in parsed:
+        if not isinstance(tag, str):
+            continue
+        stripped = tag.strip()
+        if stripped:
+            result.append(stripped)
+    return result

--- a/backend/tests/services/test_event_merging_parsing.py
+++ b/backend/tests/services/test_event_merging_parsing.py
@@ -1,0 +1,120 @@
+"""Tests for JSONB occurrence and tag parsing in ``event_merging``."""
+
+from datetime import date
+
+from api.services.event_merging import (
+    ParsedOccurrence,
+    _parse_jsonb,
+    parse_occurrences,
+    parse_tags,
+)
+
+TODAY = date(2026, 4, 10)
+
+
+# ---------------------------------------------------------------------------
+# _parse_jsonb
+# ---------------------------------------------------------------------------
+
+
+def test_parse_jsonb_passthrough_dict() -> None:
+    value = {"a": 1, "b": [1, 2]}
+    assert _parse_jsonb(value) == value
+    assert _parse_jsonb([1, 2, 3]) == [1, 2, 3]
+
+
+def test_parse_jsonb_string() -> None:
+    assert _parse_jsonb('[{"start_date": "2026-05-01"}]') == [
+        {"start_date": "2026-05-01"}
+    ]
+    assert _parse_jsonb('{"k": "v"}') == {"k": "v"}
+
+
+def test_parse_jsonb_none() -> None:
+    assert _parse_jsonb(None) is None
+
+
+def test_parse_jsonb_invalid() -> None:
+    assert _parse_jsonb("not json at all") is None
+    # Valid JSON but not a dict/list.
+    assert _parse_jsonb("42") is None
+    assert _parse_jsonb('"a string"') is None
+    # Non-string, non-container types.
+    assert _parse_jsonb(42) is None
+    assert _parse_jsonb(object()) is None
+
+
+# ---------------------------------------------------------------------------
+# parse_occurrences
+# ---------------------------------------------------------------------------
+
+
+def test_parse_occurrences_filters_past() -> None:
+    raw = [{"start_date": "2020-01-01"}]
+    assert parse_occurrences(raw, today=TODAY) == []
+
+
+def test_parse_occurrences_filters_far_future() -> None:
+    raw = [{"start_date": "2099-01-01"}]
+    assert parse_occurrences(raw, today=TODAY) == []
+
+
+def test_parse_occurrences_keeps_end_date() -> None:
+    raw = [
+        {
+            "start_date": "2026-04-15",
+            "start_time": "19:00",
+            "end_date": "2026-04-16",
+            "end_time": "21:00",
+        }
+    ]
+    result = parse_occurrences(raw, today=TODAY)
+    assert result == [
+        ParsedOccurrence(
+            start_date=date(2026, 4, 15),
+            start_time="19:00",
+            end_date=date(2026, 4, 16),
+            end_time="21:00",
+        )
+    ]
+
+
+def test_parse_occurrences_handles_bad_format() -> None:
+    raw = [
+        {"start_date": "not-a-date"},
+        {"start_date": "2026-04-15", "end_date": "garbage"},
+        "not a dict",
+        {},
+        None,
+    ]
+    result = parse_occurrences(raw, today=TODAY)
+    assert len(result) == 1
+    assert result[0].start_date == date(2026, 4, 15)
+    assert result[0].end_date is None
+
+
+def test_parse_occurrences_accepts_json_string() -> None:
+    raw = '[{"start_date": "2026-04-20"}]'
+    result = parse_occurrences(raw, today=TODAY)
+    assert [o.start_date for o in result] == [date(2026, 4, 20)]
+
+
+def test_parse_occurrences_handles_none_raw() -> None:
+    assert parse_occurrences(None, today=TODAY) == []
+
+
+# ---------------------------------------------------------------------------
+# parse_tags
+# ---------------------------------------------------------------------------
+
+
+def test_parse_tags_list() -> None:
+    assert parse_tags(["Music", "Art"]) == ["Music", "Art"]
+    assert parse_tags('["Music", "Art"]') == ["Music", "Art"]
+
+
+def test_parse_tags_drops_non_string() -> None:
+    assert parse_tags(["Music", "", None, 42, "  Art  "]) == ["Music", "Art"]
+    assert parse_tags(None) == []
+    assert parse_tags("not json") == []
+    assert parse_tags({"not": "a list"}) == []


### PR DESCRIPTION
## What
Add pure helpers to parse and filter the JSONB `occurrences` and `tags` columns from `ExtractedEvent`, with 14-day future grace and 90-day look-ahead. Ports `pipeline/merger.py:364-375, 563-610`.

## Why
`ExtractedEvent` stores occurrences and tags as raw JSONB blobs. Before any merge or create operation can proceed, these blobs must be parsed and filtered: occurrences outside the `[today, today+90d]` window are irrelevant, and non-string tags must be dropped. This PR provides the pure parsing layer consumed by all downstream DB operations.

## How
- Add `FUTURE_LIMIT_DAYS = 90` and `ARCHIVE_GRACE_DAYS = 14` constants
- Add `ParsedOccurrence` frozen dataclass with start_date, start_time, end_date, end_time fields
- Implement `_parse_jsonb`: accepts None, list/dict, or JSON string
- Implement `parse_occurrences`: filter to `today <= start_date <= today+90d`, parse time/end fields safely
- Implement `parse_tags`: coerce JSONB, drop non-str entries, strip whitespace

## Changes
- `backend/api/services/event_merging.py`: Append `FUTURE_LIMIT_DAYS`, `ARCHIVE_GRACE_DAYS`, `ParsedOccurrence`, `_parse_jsonb`, `parse_occurrences`, `parse_tags`
- `backend/tests/services/test_event_merging_parsing.py`: Ten test functions covering passthrough dict, JSON string parsing, None handling, invalid input, past filtering, far-future filtering, end_date preservation, bad format handling, tag list parsing, and non-string tag dropping

## Validation
- [x] `cd backend && uv run ruff check .`
- [x] `cd backend && uv run ruff format --check .`
- [x] `cd backend && uv run mypy api/services/event_merging.py`
- [x] `cd backend && uv run pytest tests/services/test_event_merging_parsing.py -v`

## Stack
PR 4/8 for: Port event-merging service (Issue #111)
