### PR TITLE
feat: Async dedup-index loader

### DIFF
--- a/backend/api/services/event_merging.py
+++ b/backend/api/services/event_merging.py
@@ -13,9 +13,16 @@ from __future__ import annotations
 import json
 import re
 import unicodedata
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import date, datetime, timedelta
 from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from api.models.base import EventStatus
+from api.models.event import Event, EventOccurrence, EventSource
+from api.models.location import Location
 
 STOP_WORDS: frozenset[str] = frozenset(
     {"the", "and", "for", "with", "from", "into", "your"}
@@ -487,3 +494,143 @@ def parse_tags(raw: object) -> list[str]:
         if stripped:
             result.append(stripped)
     return result
+
+
+# ---------------------------------------------------------------------------
+# Dedup index — ported from ``pipeline/merger.py`` lines 437-520.
+# ---------------------------------------------------------------------------
+
+RECENT_BUFFER_DAYS: int = 10
+
+
+@dataclass(frozen=True)
+class EventCandidate:
+    """A lightweight reference to an existing event for dedup matching."""
+
+    id: int
+    name: str
+
+
+@dataclass
+class DedupIndex:
+    """Three lookup indexes plus a per-event set of future occurrence dates.
+
+    Mirrors the in-memory maps built at the top of
+    ``pipeline/merger.py:merge_extracted_events`` so the async backend can
+    perform the same dedup lookups by location_id, coordinates, or
+    source_id.
+    """
+
+    by_location_id: dict[int, list[EventCandidate]] = field(default_factory=dict)
+    by_coords: dict[tuple[float, float], list[EventCandidate]] = field(
+        default_factory=dict
+    )
+    by_source_id: dict[int, list[EventCandidate]] = field(default_factory=dict)
+    dates_by_event_id: dict[int, set[str]] = field(default_factory=dict)
+
+    def add(
+        self,
+        candidate: EventCandidate,
+        *,
+        location_id: int | None,
+        lat: float | None,
+        lng: float | None,
+        source_id: int | None,
+        dates: set[str],
+    ) -> None:
+        """Insert ``candidate`` into every index for which it has a key."""
+        if location_id is not None:
+            self.by_location_id.setdefault(location_id, []).append(candidate)
+
+        if lat is not None and lng is not None:
+            key = (round(float(lat), 5), round(float(lng), 5))
+            self.by_coords.setdefault(key, []).append(candidate)
+
+        if source_id is not None:
+            self.by_source_id.setdefault(source_id, []).append(candidate)
+
+        self.dates_by_event_id[candidate.id] = set(dates)
+
+
+async def load_dedup_index(db: AsyncSession, *, today: date) -> DedupIndex:
+    """Build a :class:`DedupIndex` of active events with future occurrences.
+
+    Ported from ``pipeline/merger.py`` lines 437-520. Selects active,
+    non-soft-deleted events whose occurrences fall within
+    ``[today - RECENT_BUFFER_DAYS, today + FUTURE_LIMIT_DAYS]``, and
+    populates the three lookup maps plus the per-event date set used for
+    downstream dedup.
+    """
+    recent_cutoff = today - timedelta(days=RECENT_BUFFER_DAYS)
+    future_limit = today + timedelta(days=FUTURE_LIMIT_DAYS)
+
+    stmt = (
+        select(
+            Event.id,
+            Event.name,
+            Event.location_id,
+            Location.lat,
+            Location.lng,
+            EventOccurrence.start_date,
+        )
+        .join(EventOccurrence, EventOccurrence.event_id == Event.id)
+        .join(Location, Location.id == Event.location_id, isouter=True)
+        .where(
+            Event.status == EventStatus.active,
+            Event.deleted_at.is_(None),
+            EventOccurrence.start_date >= recent_cutoff,
+            EventOccurrence.start_date <= future_limit,
+        )
+    )
+    rows = (await db.execute(stmt)).all()
+
+    index = DedupIndex()
+    # Accumulate per-event metadata before touching indexes so we only call
+    # ``add`` once per event (preserving the merger's de-duplication
+    # behaviour across multiple matching occurrences).
+    per_event: dict[int, dict[str, Any]] = {}
+    for event_id, name, location_id, lat, lng, start_date in rows:
+        entry = per_event.setdefault(
+            event_id,
+            {
+                "name": name,
+                "location_id": location_id,
+                "lat": lat,
+                "lng": lng,
+                "dates": set(),
+            },
+        )
+        if start_date is not None:
+            entry["dates"].add(str(start_date))
+
+    if not per_event:
+        return index
+
+    # Second query: source_ids for these events.
+    source_stmt = select(EventSource.event_id, EventSource.source_id).where(
+        EventSource.event_id.in_(per_event.keys()),
+        EventSource.source_id.is_not(None),
+    )
+    source_rows = (await db.execute(source_stmt)).all()
+
+    source_ids_by_event: dict[int, list[int]] = {}
+    for event_id, source_id in source_rows:
+        source_ids_by_event.setdefault(event_id, []).append(source_id)
+
+    for event_id, meta in per_event.items():
+        candidate = EventCandidate(id=event_id, name=meta["name"])
+        source_ids = source_ids_by_event.get(event_id, [])
+        # Insert into location/coord indexes once per event.
+        index.add(
+            candidate,
+            location_id=meta["location_id"],
+            lat=meta["lat"],
+            lng=meta["lng"],
+            source_id=None,
+            dates=meta["dates"],
+        )
+        # Then append to the source index once per (event, source).
+        for source_id in source_ids:
+            index.by_source_id.setdefault(source_id, []).append(candidate)
+
+    return index

--- a/backend/tests/services/test_event_merging_index.py
+++ b/backend/tests/services/test_event_merging_index.py
@@ -1,0 +1,157 @@
+"""Tests for the async dedup-index loader."""
+
+from datetime import date, timedelta
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from api.models.base import EventStatus, SourceType
+from api.models.event import Event, EventOccurrence, EventSource
+from api.models.location import Location
+from api.models.source import Source
+from api.services.event_merging import (
+    DedupIndex,
+    EventCandidate,
+    load_dedup_index,
+)
+
+TODAY = date(2026, 4, 10)
+
+
+async def _make_location(
+    db: AsyncSession,
+    *,
+    name: str = "Test Venue",
+    lat: float | None = None,
+    lng: float | None = None,
+) -> Location:
+    loc = Location(name=name, lat=lat, lng=lng, emoji="\U0001f3a8")
+    db.add(loc)
+    await db.flush()
+    return loc
+
+
+async def _make_event(
+    db: AsyncSession,
+    *,
+    name: str,
+    location: Location,
+    status: EventStatus = EventStatus.active,
+    occurrence_offsets: list[int] | None = None,
+) -> Event:
+    """Create an Event with occurrences at ``TODAY + offset_days``."""
+    event = Event(name=name, location_id=location.id, status=status)
+    db.add(event)
+    await db.flush()
+
+    for offset in occurrence_offsets or [1]:
+        db.add(
+            EventOccurrence(
+                event_id=event.id,
+                start_date=TODAY + timedelta(days=offset),
+            )
+        )
+    await db.flush()
+    return event
+
+
+async def _make_source(db: AsyncSession, *, name: str = "Test Source") -> Source:
+    source = Source(name=name, type=SourceType.crawler)
+    db.add(source)
+    await db.flush()
+    return source
+
+
+@pytest.mark.asyncio
+async def test_load_dedup_index_empty(db_session: AsyncSession) -> None:
+    index = await load_dedup_index(db_session, today=TODAY)
+    assert isinstance(index, DedupIndex)
+    assert index.by_location_id == {}
+    assert index.by_coords == {}
+    assert index.by_source_id == {}
+    assert index.dates_by_event_id == {}
+
+
+@pytest.mark.asyncio
+async def test_load_dedup_index_groups_by_location_id(
+    db_session: AsyncSession,
+) -> None:
+    loc = await _make_location(db_session, name="Loc A")
+    event = await _make_event(
+        db_session, name="Event A", location=loc, occurrence_offsets=[2]
+    )
+
+    index = await load_dedup_index(db_session, today=TODAY)
+
+    assert loc.id in index.by_location_id
+    assert index.by_location_id[loc.id] == [EventCandidate(id=event.id, name="Event A")]
+    assert index.dates_by_event_id[event.id] == {str(TODAY + timedelta(days=2))}
+
+
+@pytest.mark.asyncio
+async def test_load_dedup_index_groups_by_coords(db_session: AsyncSession) -> None:
+    loc = await _make_location(db_session, name="Loc B", lat=40.7, lng=-74.0)
+    event = await _make_event(db_session, name="Event B", location=loc)
+
+    index = await load_dedup_index(db_session, today=TODAY)
+
+    key = (round(40.7, 5), round(-74.0, 5))
+    assert key in index.by_coords
+    assert index.by_coords[key] == [EventCandidate(id=event.id, name="Event B")]
+
+
+@pytest.mark.asyncio
+async def test_load_dedup_index_groups_by_source_id(
+    db_session: AsyncSession,
+) -> None:
+    loc = await _make_location(db_session, name="Loc C", lat=40.7, lng=-74.0)
+    event = await _make_event(db_session, name="Event C", location=loc)
+    source = await _make_source(db_session, name="Src C")
+    db_session.add(EventSource(event_id=event.id, source_id=source.id))
+    await db_session.flush()
+
+    index = await load_dedup_index(db_session, today=TODAY)
+
+    assert source.id in index.by_source_id
+    assert index.by_source_id[source.id] == [
+        EventCandidate(id=event.id, name="Event C")
+    ]
+    # Event with location_id, source_id, and coords should appear in all
+    # three indexes.
+    assert index.by_location_id[loc.id][0].id == event.id
+    assert index.by_coords[(round(40.7, 5), round(-74.0, 5))][0].id == event.id
+
+
+@pytest.mark.asyncio
+async def test_load_dedup_index_excludes_archived(db_session: AsyncSession) -> None:
+    loc = await _make_location(db_session, name="Loc D")
+    await _make_event(
+        db_session,
+        name="Archived",
+        location=loc,
+        status=EventStatus.archived,
+    )
+
+    index = await load_dedup_index(db_session, today=TODAY)
+
+    assert index.by_location_id == {}
+    assert index.dates_by_event_id == {}
+
+
+@pytest.mark.asyncio
+async def test_load_dedup_index_excludes_events_with_only_past_occurrences(
+    db_session: AsyncSession,
+) -> None:
+    loc = await _make_location(db_session, name="Loc E")
+    # Occurrence is older than today - RECENT_BUFFER_DAYS (10).
+    await _make_event(
+        db_session,
+        name="Old",
+        location=loc,
+        occurrence_offsets=[-30],
+    )
+
+    index = await load_dedup_index(db_session, today=TODAY)
+
+    assert index.by_location_id == {}
+    assert index.dates_by_event_id == {}


### PR DESCRIPTION
## What
First DB-touching PR. Introduce the `DedupIndex` dataclass and an async loader that builds three lookup indexes (by location_id, by coords, by source_id) plus the per-event future-date set. Ports `pipeline/merger.py:437-520`.

## Why
Efficient deduplication requires pre-loading active events into in-memory indexes keyed by location, coordinates, and source so that candidate lookup is O(1) per extracted event rather than a query per event. This is the foundation of the merge loop introduced in PR 8.

## How
- Add `EventCandidate` dataclass (id, name) and `DedupIndex` dataclass with the three lookup maps and a `dates_by_event_id` map, plus an `add` method
- Implement `load_dedup_index`: query active non-deleted events with occurrences in `[today-10d, today+90d]`, left-join locations for lat/lng, second query for `EventSource.source_id`, third for `EventOccurrence.start_date`; populate all four maps; round coords to 5 decimals

## Changes
- `backend/api/services/event_merging.py`: Append `EventCandidate`, `DedupIndex`, `load_dedup_index`; add SQLAlchemy/model imports
- `backend/tests/services/test_event_merging_index.py`: Six async tests covering empty DB, location grouping, coord grouping, source grouping, archived-event exclusion, and past-occurrence exclusion

## Validation
- [x] `cd backend && uv run ruff check .`
- [x] `cd backend && uv run ruff format --check .`
- [x] `cd backend && uv run mypy api/services/event_merging.py`
- [x] `cd backend && uv run pytest tests/services/test_event_merging_index.py -v`

## Stack
PR 5/8 for: Port event-merging service (Issue #111)
