### PR TITLE
feat: Match selection and audit logging

### DIFF
--- a/backend/api/services/event_merging.py
+++ b/backend/api/services/event_merging.py
@@ -20,7 +20,8 @@ from typing import Any
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from api.models.base import EventStatus
+from api.models.base import EventStatus, ExtractedEventStatus
+from api.models.crawl import ExtractedEventLog
 from api.models.event import Event, EventOccurrence, EventSource
 from api.models.location import Location
 
@@ -634,3 +635,119 @@ async def load_dedup_index(db: AsyncSession, *, today: date) -> DedupIndex:
             index.by_source_id.setdefault(source_id, []).append(candidate)
 
     return index
+
+
+# ---------------------------------------------------------------------------
+# Match selection and audit logging
+# (ported from ``pipeline/merger.py`` lines 378-384, 617-652)
+# ---------------------------------------------------------------------------
+
+
+def find_best_match(
+    name: str,
+    extracted_dates: set[str],
+    candidates: list[EventCandidate],
+    dates_by_event_id: dict[int, set[str]],
+) -> int | None:
+    """Find the best matching event id among ``candidates``.
+
+    Requires a date overlap between ``extracted_dates`` and each
+    candidate's occurrence dates, then uses :func:`are_names_similar` to
+    filter similar names. Prefers an exact normalized-name match; if none
+    is found, returns the first partial match.
+
+    Ported from ``pipeline/merger.py`` lines 621-632.
+    """
+    norm_name = normalize_name_for_dedup(name)
+    best_id: int | None = None
+    for existing in candidates:
+        existing_dates = dates_by_event_id.get(existing.id, set())
+        if not (extracted_dates & existing_dates):
+            continue
+        if not are_names_similar(name, existing.name):
+            continue
+        if normalize_name_for_dedup(existing.name) == norm_name:
+            return existing.id
+        if best_id is None:
+            best_id = existing.id
+    return best_id
+
+
+def select_matched_event_id(
+    *,
+    name: str,
+    extracted_dates: set[str],
+    location_id: int | None,
+    lat: float | None,
+    lng: float | None,
+    source_id: int,
+    index: DedupIndex,
+) -> int | None:
+    """Return an existing event id using location -> coords -> source fallback.
+
+    Ported from ``pipeline/merger.py`` lines 634-652. Tries, in order:
+
+    1. Exact ``location_id`` lookup in :attr:`DedupIndex.by_location_id`.
+    2. Rounded ``(lat, lng)`` lookup in :attr:`DedupIndex.by_coords`.
+    3. ``source_id`` lookup in :attr:`DedupIndex.by_source_id`.
+
+    Each candidate list is resolved via :func:`find_best_match`.
+    """
+    # 1. Try matching by location_id first (most precise and reliable).
+    if location_id is not None and location_id in index.by_location_id:
+        matched = find_best_match(
+            name,
+            extracted_dates,
+            index.by_location_id[location_id],
+            index.dates_by_event_id,
+        )
+        if matched is not None:
+            return matched
+
+    # 2. Fallback: match by rounded coordinates.
+    if lat is not None and lng is not None:
+        key = (round(float(lat), 5), round(float(lng), 5))
+        if key in index.by_coords:
+            matched = find_best_match(
+                name,
+                extracted_dates,
+                index.by_coords[key],
+                index.dates_by_event_id,
+            )
+            if matched is not None:
+                return matched
+
+    # 3. Last-resort fallback: match by source_id.
+    if source_id in index.by_source_id:
+        matched = find_best_match(
+            name,
+            extracted_dates,
+            index.by_source_id[source_id],
+            index.dates_by_event_id,
+        )
+        if matched is not None:
+            return matched
+
+    return None
+
+
+async def log_extracted_event(
+    db: AsyncSession,
+    *,
+    extracted_event_id: int,
+    status: ExtractedEventStatus,
+    event_id: int | None = None,
+    message: str | None = None,
+) -> None:
+    """Insert an :class:`ExtractedEventLog` row. Does not commit.
+
+    Ported from ``pipeline/merger.py`` lines 378-384.
+    """
+    db.add(
+        ExtractedEventLog(
+            extracted_event_id=extracted_event_id,
+            status=status,
+            event_id=event_id,
+            message=message,
+        )
+    )

--- a/backend/tests/services/test_event_merging_match.py
+++ b/backend/tests/services/test_event_merging_match.py
@@ -1,0 +1,210 @@
+"""Tests for match selection and audit logging helpers."""
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from api.models.base import (
+    CrawlJobStatus,
+    CrawlResultStatus,
+    ExtractedEventStatus,
+    SourceType,
+)
+from api.models.crawl import (
+    CrawlJob,
+    CrawlResult,
+    ExtractedEvent,
+    ExtractedEventLog,
+)
+from api.models.source import Source
+from api.services.event_merging import (
+    DedupIndex,
+    EventCandidate,
+    find_best_match,
+    log_extracted_event,
+    select_matched_event_id,
+)
+
+
+def test_find_best_match_prefers_exact_normalized() -> None:
+    candidates = [
+        EventCandidate(id=1, name="Jazz Night at the Park"),
+        EventCandidate(id=2, name="Jazz Night"),
+    ]
+    dates_by_event_id = {
+        1: {"2026-04-11"},
+        2: {"2026-04-11"},
+    }
+    result = find_best_match(
+        "Jazz Night",
+        {"2026-04-11"},
+        candidates,
+        dates_by_event_id,
+    )
+    assert result == 2
+
+
+def test_find_best_match_requires_date_overlap() -> None:
+    candidates = [EventCandidate(id=1, name="Jazz Night")]
+    dates_by_event_id = {1: {"2026-05-01"}}
+    result = find_best_match(
+        "Jazz Night",
+        {"2026-04-11"},
+        candidates,
+        dates_by_event_id,
+    )
+    assert result is None
+
+
+def test_find_best_match_returns_none_when_no_candidates() -> None:
+    result = find_best_match(
+        "Jazz Night",
+        {"2026-04-11"},
+        [],
+        {},
+    )
+    assert result is None
+
+
+def _index_with(
+    *,
+    location_id: int | None = None,
+    coords: tuple[float, float] | None = None,
+    source_id: int | None = None,
+    candidate: EventCandidate,
+    dates: set[str],
+) -> DedupIndex:
+    index = DedupIndex()
+    if location_id is not None:
+        index.by_location_id[location_id] = [candidate]
+    if coords is not None:
+        index.by_coords[coords] = [candidate]
+    if source_id is not None:
+        index.by_source_id[source_id] = [candidate]
+    index.dates_by_event_id[candidate.id] = dates
+    return index
+
+
+def test_select_matched_event_id_location_first() -> None:
+    loc_candidate = EventCandidate(id=10, name="Jazz Night")
+    coord_candidate = EventCandidate(id=20, name="Jazz Night")
+    source_candidate = EventCandidate(id=30, name="Jazz Night")
+
+    index = DedupIndex()
+    index.by_location_id[100] = [loc_candidate]
+    index.by_coords[(round(40.7, 5), round(-74.0, 5))] = [coord_candidate]
+    index.by_source_id[1] = [source_candidate]
+    index.dates_by_event_id[10] = {"2026-04-11"}
+    index.dates_by_event_id[20] = {"2026-04-11"}
+    index.dates_by_event_id[30] = {"2026-04-11"}
+
+    result = select_matched_event_id(
+        name="Jazz Night",
+        extracted_dates={"2026-04-11"},
+        location_id=100,
+        lat=40.7,
+        lng=-74.0,
+        source_id=1,
+        index=index,
+    )
+    assert result == 10
+
+
+def test_select_matched_event_id_falls_back_to_coords() -> None:
+    coord_candidate = EventCandidate(id=20, name="Jazz Night")
+    source_candidate = EventCandidate(id=30, name="Jazz Night")
+
+    index = DedupIndex()
+    index.by_coords[(round(40.7, 5), round(-74.0, 5))] = [coord_candidate]
+    index.by_source_id[1] = [source_candidate]
+    index.dates_by_event_id[20] = {"2026-04-11"}
+    index.dates_by_event_id[30] = {"2026-04-11"}
+
+    # location_id is None, so location lookup is skipped.
+    result = select_matched_event_id(
+        name="Jazz Night",
+        extracted_dates={"2026-04-11"},
+        location_id=None,
+        lat=40.7,
+        lng=-74.0,
+        source_id=1,
+        index=index,
+    )
+    assert result == 20
+
+
+def test_select_matched_event_id_falls_back_to_source() -> None:
+    source_candidate = EventCandidate(id=30, name="Jazz Night")
+    index = _index_with(
+        source_id=1,
+        candidate=source_candidate,
+        dates={"2026-04-11"},
+    )
+
+    result = select_matched_event_id(
+        name="Jazz Night",
+        extracted_dates={"2026-04-11"},
+        location_id=None,
+        lat=None,
+        lng=None,
+        source_id=1,
+        index=index,
+    )
+    assert result == 30
+
+
+async def _seed_extracted_event(db: AsyncSession) -> int:
+    source = Source(name="Src", type=SourceType.crawler)
+    db.add(source)
+    await db.flush()
+
+    job = CrawlJob(status=CrawlJobStatus.running)
+    db.add(job)
+    await db.flush()
+
+    result = CrawlResult(
+        crawl_job_id=job.id,
+        source_id=source.id,
+        status=CrawlResultStatus.extracted,
+    )
+    db.add(result)
+    await db.flush()
+
+    extracted = ExtractedEvent(
+        crawl_result_id=result.id,
+        name="Jazz Night",
+    )
+    db.add(extracted)
+    await db.flush()
+    return extracted.id
+
+
+@pytest.mark.asyncio
+async def test_log_extracted_event_writes_row(db_session: AsyncSession) -> None:
+    extracted_event_id = await _seed_extracted_event(db_session)
+
+    await log_extracted_event(
+        db_session,
+        extracted_event_id=extracted_event_id,
+        status=ExtractedEventStatus.skipped_duplicate,
+        event_id=None,
+        message="already exists",
+    )
+    await db_session.flush()
+
+    rows = (
+        (
+            await db_session.execute(
+                select(ExtractedEventLog).where(
+                    ExtractedEventLog.extracted_event_id == extracted_event_id
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(rows) == 1
+    log = rows[0]
+    assert log.status == ExtractedEventStatus.skipped_duplicate
+    assert log.event_id is None
+    assert log.message == "already exists"


### PR DESCRIPTION
## What
Add the best-match selection logic (location -> coords -> source fallback) and the async `log_extracted_event` helper that writes `ExtractedEventLog` rows. Ports `pipeline/merger.py:378-384, 617-652`.

## Why
Once candidates are retrieved from the `DedupIndex`, `find_best_match` applies the similarity logic from PRs 1-3 to select the best existing event; `select_matched_event_id` wraps it with the three-tier fallback strategy. `log_extracted_event` provides the audit trail required by the admin dashboard to show processing outcomes.

## How
- Implement `find_best_match`: iterate candidates, require date overlap, use `are_names_similar`, prefer exact normalized-name match, else first partial match
- Implement `select_matched_event_id`: try location_id index, then coords index, then source_id fallback
- Implement `log_extracted_event`: insert `ExtractedEventLog` row with caller-owned transaction (no commit)

## Changes
- `backend/api/services/event_merging.py`: Append `find_best_match`, `select_matched_event_id`, `log_extracted_event`; add `ExtractedEventLog`/`ExtractedEventStatus` imports
- `backend/tests/services/test_event_merging_match.py`: Seven test functions covering exact-match preference, date-overlap requirement, empty-candidates case, location-first priority, coords fallback, source fallback, and DB row insertion

## Validation
- [x] `cd backend && uv run ruff check .`
- [x] `cd backend && uv run ruff format --check .`
- [x] `cd backend && uv run mypy api/services/event_merging.py`
- [x] `cd backend && uv run pytest tests/services/test_event_merging_match.py -v`

## Stack
PR 6/8 for: Port event-merging service (Issue #111)
