### PR TITLE
feat: Top-level orchestrator and 14-day archiving

### DIFF
--- a/backend/api/services/event_merging.py
+++ b/backend/api/services/event_merging.py
@@ -17,11 +17,11 @@ from dataclasses import dataclass, field
 from datetime import date, datetime, timedelta
 from typing import Any
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from api.models.base import EventStatus, ExtractedEventStatus
-from api.models.crawl import ExtractedEventLog
+from api.models.base import CrawlResultStatus, EventStatus, ExtractedEventStatus
+from api.models.crawl import CrawlResult, ExtractedEvent, ExtractedEventLog
 from api.models.event import Event, EventOccurrence, EventSource, EventTag, EventUrl
 from api.models.location import Location
 from api.models.tag import Tag
@@ -924,3 +924,385 @@ async def create_new_event(
     await db.flush()
 
     return new_event_id
+
+
+# ---------------------------------------------------------------------------
+# Top-level orchestrator and 14-day archiving
+# (ported from ``pipeline/merger.py`` lines 387-431, 525-562, 808-868
+# and ``pipeline/db.py:archive_outdated_events`` lines 447-548)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class MergeResult:
+    """Return value of :func:`merge_extracted_events`."""
+
+    new_events_count: int
+    merged_count: int
+    archived_count: int
+
+
+async def archive_outdated_events(
+    db: AsyncSession,
+    *,
+    source_id: int,
+    today: date,
+) -> tuple[int, list[tuple[int, str, date]]]:
+    """Archive events whose sources no longer list them in their latest crawl.
+
+    An active event linked to ``source_id`` is archived when, for **every**
+    source that has ever linked to it, the most recent crawl result from
+    that source (in ``processed``/``extracted`` status) does not reference
+    the event. A 14-day grace period applies: events with any occurrence
+    whose ``start_date >= today + 14 days`` are preserved.
+
+    Returns a tuple of ``(archived_count, upcoming_warnings)`` where
+    ``upcoming_warnings`` is a list of ``(event_id, name, next_occurrence)``
+    tuples for events that were archived despite having upcoming
+    occurrences (those strictly after ``today`` but strictly before the
+    14-day grace threshold).
+    """
+    # Candidate events: active, non-deleted, linked via EventSource to source_id.
+    candidate_stmt = (
+        select(Event.id, Event.name)
+        .join(EventSource, EventSource.event_id == Event.id)
+        .where(
+            Event.status == EventStatus.active,
+            Event.deleted_at.is_(None),
+            EventSource.source_id == source_id,
+        )
+        .distinct()
+    )
+    candidate_rows = (await db.execute(candidate_stmt)).all()
+    if not candidate_rows:
+        return 0, []
+
+    candidate_ids = [row[0] for row in candidate_rows]
+    names_by_id: dict[int, str] = {row[0]: row[1] for row in candidate_rows}
+
+    # All (event_id, source_id, extracted_event_id) triples for candidate events.
+    links_stmt = select(
+        EventSource.event_id,
+        EventSource.source_id,
+        EventSource.extracted_event_id,
+    ).where(EventSource.event_id.in_(candidate_ids))
+    link_rows = (await db.execute(links_stmt)).all()
+
+    # Map: event_id -> set of source_ids it's linked to.
+    sources_by_event: dict[int, set[int]] = {}
+    # Map: (event_id, source_id) -> set of extracted_event_ids
+    ee_by_event_source: dict[tuple[int, int], set[int]] = {}
+    all_source_ids: set[int] = set()
+    for event_id, src_id, ee_id in link_rows:
+        if src_id is None:
+            continue
+        sources_by_event.setdefault(event_id, set()).add(src_id)
+        all_source_ids.add(src_id)
+        if ee_id is not None:
+            ee_by_event_source.setdefault((event_id, src_id), set()).add(ee_id)
+
+    # Latest (by id) crawl_result per source in processed/extracted status.
+    latest_cr_by_source: dict[int, int] = {}
+    if all_source_ids:
+        latest_stmt = (
+            select(
+                CrawlResult.source_id,
+                func.max(CrawlResult.id).label("max_id"),
+            )
+            .where(
+                CrawlResult.source_id.in_(all_source_ids),
+                CrawlResult.status.in_(
+                    (CrawlResultStatus.processed, CrawlResultStatus.extracted)
+                ),
+            )
+            .group_by(CrawlResult.source_id)
+        )
+        for src_id, max_id in (await db.execute(latest_stmt)).all():
+            if max_id is not None:
+                latest_cr_by_source[src_id] = max_id
+
+    # For each latest crawl_result, pull the set of extracted_event_ids it produced.
+    ees_in_latest_cr: dict[int, set[int]] = {}
+    if latest_cr_by_source:
+        ee_stmt = select(ExtractedEvent.id, ExtractedEvent.crawl_result_id).where(
+            ExtractedEvent.crawl_result_id.in_(latest_cr_by_source.values())
+        )
+        for ee_id_val, cr_id in (await db.execute(ee_stmt)).all():
+            ees_in_latest_cr.setdefault(cr_id, set()).add(ee_id_val)
+
+    # Occurrences per candidate event — for grace period + upcoming warnings.
+    occ_stmt = select(EventOccurrence.event_id, EventOccurrence.start_date).where(
+        EventOccurrence.event_id.in_(candidate_ids)
+    )
+    occs_by_event: dict[int, list[date]] = {}
+    for event_id, start_date in (await db.execute(occ_stmt)).all():
+        if start_date is not None:
+            occs_by_event.setdefault(event_id, []).append(start_date)
+
+    grace_threshold = today + timedelta(days=ARCHIVE_GRACE_DAYS)
+
+    archived_count = 0
+    upcoming_warnings: list[tuple[int, str, date]] = []
+
+    for event_id in candidate_ids:
+        event_sources = sources_by_event.get(event_id, set())
+        if not event_sources:
+            continue
+
+        # An event is "still seen" if ANY of its linked sources' latest
+        # crawl contains any of its extracted_events.
+        still_seen = False
+        for src_id in event_sources:
+            latest_cr = latest_cr_by_source.get(src_id)
+            if latest_cr is None:
+                # No latest crawl -> treat source as "not seen here".
+                continue
+            latest_ees = ees_in_latest_cr.get(latest_cr, set())
+            event_ees = ee_by_event_source.get((event_id, src_id), set())
+            if event_ees & latest_ees:
+                still_seen = True
+                break
+        if still_seen:
+            continue
+
+        # 14-day grace: preserve if any occurrence is on/after today+14d.
+        occs = occs_by_event.get(event_id, [])
+        if any(d >= grace_threshold for d in occs):
+            continue
+
+        # Collect next-upcoming-occurrence warning (strictly > today).
+        future = sorted(d for d in occs if d > today)
+        if future:
+            upcoming_warnings.append((event_id, names_by_id[event_id], future[0]))
+
+        # Archive in-place.
+        event_obj = (
+            await db.execute(select(Event).where(Event.id == event_id))
+        ).scalar_one_or_none()
+        if event_obj is None:
+            continue
+        event_obj.status = EventStatus.archived
+        archived_count += 1
+
+    await db.flush()
+    return archived_count, upcoming_warnings
+
+
+async def merge_extracted_events(
+    db: AsyncSession,
+    *,
+    crawl_job_id: int | None = None,
+    today: date | None = None,
+) -> MergeResult:
+    """Top-level orchestrator: merge unprocessed extracted events and archive.
+
+    Loads every :class:`ExtractedEvent` whose parent crawl result is in
+    ``processed`` status and which has no :class:`EventSource` row yet,
+    runs each through :func:`select_matched_event_id` and either
+    :func:`merge_into_existing_event` or :func:`create_new_event`, updates
+    an in-memory dedup index so within-batch duplicates match, and finally
+    archives outdated events per affected source.
+
+    The caller owns the transaction; the orchestrator only calls
+    :meth:`AsyncSession.flush`.
+    """
+    if today is None:
+        today = date.today()
+
+    # Load unprocessed extracted events joined with their crawl_result
+    # (for source_id) and optional location (for lat/lng). Left-join
+    # EventSource to filter out already-processed rows.
+    unprocessed_stmt = (
+        select(
+            ExtractedEvent.id,
+            ExtractedEvent.name,
+            ExtractedEvent.short_name,
+            ExtractedEvent.description,
+            ExtractedEvent.emoji,
+            ExtractedEvent.sublocation,
+            ExtractedEvent.location_id,
+            ExtractedEvent.url,
+            CrawlResult.source_id,
+            Location.lat,
+            Location.lng,
+            ExtractedEvent.occurrences,
+            ExtractedEvent.tags,
+        )
+        .join(CrawlResult, CrawlResult.id == ExtractedEvent.crawl_result_id)
+        .join(Location, Location.id == ExtractedEvent.location_id, isouter=True)
+        .outerjoin(EventSource, EventSource.extracted_event_id == ExtractedEvent.id)
+        .where(
+            CrawlResult.status == CrawlResultStatus.processed,
+            EventSource.id.is_(None),
+        )
+    )
+    rows = (await db.execute(unprocessed_stmt)).all()
+
+    if not rows:
+        return MergeResult(new_events_count=0, merged_count=0, archived_count=0)
+
+    index = await load_dedup_index(db, today=today)
+
+    new_events_count = 0
+    merged_count = 0
+    affected_source_ids: set[int] = set()
+
+    for row in rows:
+        (
+            ee_id,
+            name,
+            short_name,
+            description,
+            emoji,
+            sublocation,
+            location_id,
+            url,
+            source_id,
+            lat,
+            lng,
+            raw_occurrences,
+            raw_tags,
+        ) = row
+
+        if not name:
+            continue
+
+        # source_id is a system invariant.
+        if source_id is None:
+            raise RuntimeError(
+                f"extracted_event {ee_id} has no source_id via crawl_results; "
+                "this violates a system invariant"
+            )
+
+        affected_source_ids.add(source_id)
+
+        if location_id is None:
+            await log_extracted_event(
+                db,
+                extracted_event_id=ee_id,
+                status=ExtractedEventStatus.skipped_no_location,
+                message="No location_id on extracted event",
+            )
+            continue
+
+        valid_occurrences = parse_occurrences(raw_occurrences, today=today)
+        if not valid_occurrences:
+            await log_extracted_event(
+                db,
+                extracted_event_id=ee_id,
+                status=ExtractedEventStatus.skipped_no_occurrences,
+                message="No valid future occurrences",
+            )
+            continue
+
+        tags = parse_tags(raw_tags)
+        lat_f = float(lat) if lat is not None else None
+        lng_f = float(lng) if lng is not None else None
+
+        extracted = ExtractedEventInput(
+            ee_id=ee_id,
+            name=name,
+            short_name=short_name,
+            description=description,
+            emoji=emoji,
+            sublocation=sublocation,
+            location_id=location_id,
+            url=url,
+            source_id=source_id,
+            lat=lat_f,
+            lng=lng_f,
+            occurrences=valid_occurrences,
+            tags=tags,
+        )
+
+        extracted_dates = {
+            str(occ.start_date) for occ in valid_occurrences if occ.start_date
+        }
+
+        matched_event_id = select_matched_event_id(
+            name=name,
+            extracted_dates=extracted_dates,
+            location_id=location_id,
+            lat=lat_f,
+            lng=lng_f,
+            source_id=source_id,
+            index=index,
+        )
+
+        if matched_event_id is not None:
+            await merge_into_existing_event(
+                db, event_id=matched_event_id, extracted=extracted
+            )
+            await log_extracted_event(
+                db,
+                extracted_event_id=ee_id,
+                status=ExtractedEventStatus.merged,
+                event_id=matched_event_id,
+                message=f"Merged with existing event {matched_event_id}",
+            )
+            await db.flush()
+            merged_count += 1
+
+            # Append this source to the dedup index so within-batch
+            # duplicates from other sources still match.
+            existing = next(
+                (
+                    c
+                    for c in index.by_source_id.get(source_id, [])
+                    if c.id == matched_event_id
+                ),
+                None,
+            )
+            if existing is None:
+                matched_name = next(
+                    (
+                        c.name
+                        for candidates in index.by_location_id.values()
+                        for c in candidates
+                        if c.id == matched_event_id
+                    ),
+                    name,
+                )
+                index.by_source_id.setdefault(source_id, []).append(
+                    EventCandidate(id=matched_event_id, name=matched_name)
+                )
+            # Widen the candidate's known dates so later rows in the same
+            # batch can still match via date overlap.
+            dates = index.dates_by_event_id.setdefault(matched_event_id, set())
+            dates.update(extracted_dates)
+        else:
+            new_event_id = await create_new_event(db, extracted=extracted)
+            await log_extracted_event(
+                db,
+                extracted_event_id=ee_id,
+                status=ExtractedEventStatus.created,
+                event_id=new_event_id,
+                message=f"Created new event {new_event_id}",
+            )
+            await db.flush()
+            new_events_count += 1
+
+            candidate = EventCandidate(id=new_event_id, name=name)
+            index.add(
+                candidate,
+                location_id=location_id,
+                lat=lat_f,
+                lng=lng_f,
+                source_id=source_id,
+                dates=extracted_dates,
+            )
+
+    # Archive outdated events for every source touched by this batch.
+    total_archived = 0
+    for src_id in affected_source_ids:
+        archived, _warnings = await archive_outdated_events(
+            db, source_id=src_id, today=today
+        )
+        total_archived += archived
+
+    await db.flush()
+    return MergeResult(
+        new_events_count=new_events_count,
+        merged_count=merged_count,
+        archived_count=total_archived,
+    )

--- a/backend/tests/services/test_event_merging_orchestrator.py
+++ b/backend/tests/services/test_event_merging_orchestrator.py
@@ -1,0 +1,497 @@
+"""End-to-end tests for the :func:`merge_extracted_events` orchestrator."""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+from typing import Any
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from api.models.base import (
+    CrawlJobStatus,
+    CrawlResultStatus,
+    EventStatus,
+    ExtractedEventStatus,
+    SourceType,
+)
+from api.models.crawl import (
+    CrawlJob,
+    CrawlResult,
+    ExtractedEvent,
+    ExtractedEventLog,
+)
+from api.models.event import (
+    Event,
+    EventOccurrence,
+    EventSource,
+    EventUrl,
+)
+from api.models.location import Location
+from api.models.source import Source
+from api.services.event_merging import (
+    MergeResult,
+    merge_extracted_events,
+)
+
+TODAY = date(2026, 4, 10)
+
+
+async def _make_source(db: AsyncSession, *, name: str = "Src") -> Source:
+    source = Source(name=name, type=SourceType.crawler)
+    db.add(source)
+    await db.flush()
+    return source
+
+
+async def _make_location(db: AsyncSession, *, name: str = "Venue") -> Location:
+    loc = Location(name=name, emoji="\U0001f3a8")
+    db.add(loc)
+    await db.flush()
+    return loc
+
+
+async def _make_processed_crawl_result(
+    db: AsyncSession, *, source: Source
+) -> CrawlResult:
+    job = CrawlJob(status=CrawlJobStatus.completed)
+    db.add(job)
+    await db.flush()
+    cr = CrawlResult(
+        crawl_job_id=job.id,
+        source_id=source.id,
+        status=CrawlResultStatus.processed,
+    )
+    db.add(cr)
+    await db.flush()
+    return cr
+
+
+async def _make_extracted_event(
+    db: AsyncSession,
+    *,
+    crawl_result: CrawlResult,
+    name: str,
+    location: Location | None,
+    occurrences: list[dict[str, Any]] | None = None,
+    tags: list[str] | None = None,
+    url: str | None = "https://example.com/e",
+) -> ExtractedEvent:
+    ee = ExtractedEvent(
+        crawl_result_id=crawl_result.id,
+        name=name,
+        location_id=location.id if location else None,
+        url=url,
+        occurrences=occurrences,
+        tags=tags,
+    )
+    db.add(ee)
+    await db.flush()
+    return ee
+
+
+def _future_occ(days: int) -> dict[str, Any]:
+    return {"start_date": (TODAY + timedelta(days=days)).isoformat()}
+
+
+@pytest.mark.asyncio
+async def test_merge_creates_new_event_and_logs_created(
+    db_session: AsyncSession,
+) -> None:
+    source = await _make_source(db_session)
+    location = await _make_location(db_session)
+    cr = await _make_processed_crawl_result(db_session, source=source)
+    ee = await _make_extracted_event(
+        db_session,
+        crawl_result=cr,
+        name="Jazz Night",
+        location=location,
+        occurrences=[_future_occ(2)],
+        tags=["music"],
+    )
+
+    result = await merge_extracted_events(db_session, today=TODAY)
+
+    assert isinstance(result, MergeResult)
+    assert result.new_events_count == 1
+    assert result.merged_count == 0
+
+    event = (
+        await db_session.execute(select(Event).where(Event.name == "Jazz Night"))
+    ).scalar_one()
+    assert event.location_id == location.id
+    assert event.status == EventStatus.active
+
+    occ_count = len(
+        (
+            await db_session.execute(
+                select(EventOccurrence).where(EventOccurrence.event_id == event.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert occ_count == 1
+
+    urls = (
+        (
+            await db_session.execute(
+                select(EventUrl.url).where(EventUrl.event_id == event.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert urls == ["https://example.com/e"]
+
+    sources = (
+        (
+            await db_session.execute(
+                select(EventSource).where(EventSource.event_id == event.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(sources) == 1
+    assert sources[0].is_primary is True
+    assert sources[0].extracted_event_id == ee.id
+
+    log = (
+        await db_session.execute(
+            select(ExtractedEventLog).where(
+                ExtractedEventLog.extracted_event_id == ee.id
+            )
+        )
+    ).scalar_one()
+    assert log.status == ExtractedEventStatus.created
+    assert log.event_id == event.id
+
+
+@pytest.mark.asyncio
+async def test_merge_merges_duplicate_and_logs_merged(
+    db_session: AsyncSession,
+) -> None:
+    source = await _make_source(db_session)
+    location = await _make_location(db_session)
+
+    # Pre-existing event with an overlapping future occurrence.
+    existing = Event(name="Jazz Night", location_id=location.id)
+    db_session.add(existing)
+    await db_session.flush()
+    db_session.add(
+        EventOccurrence(event_id=existing.id, start_date=TODAY + timedelta(days=2))
+    )
+    # Link existing event to source via a prior crawl_result + extracted_event
+    # so the source appears "still seeing" it and it isn't archived.
+    prior_cr = await _make_processed_crawl_result(db_session, source=source)
+    prior_ee = ExtractedEvent(
+        crawl_result_id=prior_cr.id, name="Jazz Night", location_id=location.id
+    )
+    db_session.add(prior_ee)
+    await db_session.flush()
+    db_session.add(
+        EventSource(
+            event_id=existing.id,
+            extracted_event_id=prior_ee.id,
+            source_id=source.id,
+            is_primary=True,
+        )
+    )
+    await db_session.flush()
+
+    # New crawl_result with a duplicate extracted event.
+    cr = await _make_processed_crawl_result(db_session, source=source)
+    ee = await _make_extracted_event(
+        db_session,
+        crawl_result=cr,
+        name="Jazz Night",
+        location=location,
+        occurrences=[_future_occ(2)],
+        url="https://example.com/new",
+    )
+
+    result = await merge_extracted_events(db_session, today=TODAY)
+
+    assert result.new_events_count == 0
+    assert result.merged_count == 1
+
+    sources = (
+        (
+            await db_session.execute(
+                select(EventSource)
+                .where(EventSource.event_id == existing.id)
+                .order_by(EventSource.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(sources) == 2
+    assert sources[1].is_primary is False
+    assert sources[1].extracted_event_id == ee.id
+
+    log = (
+        await db_session.execute(
+            select(ExtractedEventLog).where(
+                ExtractedEventLog.extracted_event_id == ee.id
+            )
+        )
+    ).scalar_one()
+    assert log.status == ExtractedEventStatus.merged
+    assert log.event_id == existing.id
+
+
+@pytest.mark.asyncio
+async def test_merge_skips_missing_location(db_session: AsyncSession) -> None:
+    source = await _make_source(db_session)
+    cr = await _make_processed_crawl_result(db_session, source=source)
+    ee = await _make_extracted_event(
+        db_session,
+        crawl_result=cr,
+        name="No Venue",
+        location=None,
+        occurrences=[_future_occ(1)],
+    )
+
+    result = await merge_extracted_events(db_session, today=TODAY)
+    assert result.new_events_count == 0
+    assert result.merged_count == 0
+
+    log = (
+        await db_session.execute(
+            select(ExtractedEventLog).where(
+                ExtractedEventLog.extracted_event_id == ee.id
+            )
+        )
+    ).scalar_one()
+    assert log.status == ExtractedEventStatus.skipped_no_location
+
+
+@pytest.mark.asyncio
+async def test_merge_skips_no_valid_occurrences(db_session: AsyncSession) -> None:
+    source = await _make_source(db_session)
+    location = await _make_location(db_session)
+    cr = await _make_processed_crawl_result(db_session, source=source)
+    # All occurrences in the past -> filtered out by parse_occurrences.
+    ee = await _make_extracted_event(
+        db_session,
+        crawl_result=cr,
+        name="Past Event",
+        location=location,
+        occurrences=[
+            {"start_date": (TODAY - timedelta(days=5)).isoformat()},
+        ],
+    )
+
+    result = await merge_extracted_events(db_session, today=TODAY)
+    assert result.new_events_count == 0
+    assert result.merged_count == 0
+
+    log = (
+        await db_session.execute(
+            select(ExtractedEventLog).where(
+                ExtractedEventLog.extracted_event_id == ee.id
+            )
+        )
+    ).scalar_one()
+    assert log.status == ExtractedEventStatus.skipped_no_occurrences
+
+
+@pytest.mark.asyncio
+async def test_merge_raises_on_missing_source_id(
+    db_session: AsyncSession, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Fabricate a row with source_id=None by monkeypatching the loader.
+    source = await _make_source(db_session)
+    location = await _make_location(db_session)
+    cr = await _make_processed_crawl_result(db_session, source=source)
+    await _make_extracted_event(
+        db_session,
+        crawl_result=cr,
+        name="Bad Row",
+        location=location,
+        occurrences=[_future_occ(1)],
+    )
+
+    # Patch AsyncSession.execute to mangle the first query result only.
+    from api.services import event_merging as em
+
+    original_execute = db_session.execute
+    call_count = {"n": 0}
+
+    async def mangled_execute(stmt: Any, *args: Any, **kwargs: Any) -> Any:
+        result = await original_execute(stmt, *args, **kwargs)
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            # Replace the first (unprocessed) query's rows with source_id=None.
+            rows = result.all()
+            mangled = [
+                (
+                    r[0],
+                    r[1],
+                    r[2],
+                    r[3],
+                    r[4],
+                    r[5],
+                    r[6],
+                    r[7],
+                    None,  # source_id -> None
+                    r[9],
+                    r[10],
+                    r[11],
+                    r[12],
+                )
+                for r in rows
+            ]
+
+            class _FakeResult:
+                def all(self_inner) -> list[Any]:
+                    return mangled
+
+            return _FakeResult()
+        return result
+
+    monkeypatch.setattr(db_session, "execute", mangled_execute)
+
+    with pytest.raises(RuntimeError, match="no source_id"):
+        await em.merge_extracted_events(db_session, today=TODAY)
+
+
+@pytest.mark.asyncio
+async def test_merge_within_batch_dedup(db_session: AsyncSession) -> None:
+    source = await _make_source(db_session)
+    location = await _make_location(db_session)
+    cr = await _make_processed_crawl_result(db_session, source=source)
+
+    await _make_extracted_event(
+        db_session,
+        crawl_result=cr,
+        name="Repeat Concert",
+        location=location,
+        occurrences=[_future_occ(3)],
+        url="https://example.com/a",
+    )
+    await _make_extracted_event(
+        db_session,
+        crawl_result=cr,
+        name="Repeat Concert",
+        location=location,
+        occurrences=[_future_occ(3)],
+        url="https://example.com/b",
+    )
+
+    result = await merge_extracted_events(db_session, today=TODAY)
+
+    # Only one new event; the second row is merged into the first.
+    assert result.new_events_count == 1
+    assert result.merged_count == 1
+
+    events = (
+        (await db_session.execute(select(Event).where(Event.name == "Repeat Concert")))
+        .scalars()
+        .all()
+    )
+    assert len(events) == 1
+
+
+@pytest.mark.asyncio
+async def test_merge_archives_event_not_seen_in_latest_crawl(
+    db_session: AsyncSession,
+) -> None:
+    source = await _make_source(db_session)
+    location = await _make_location(db_session)
+
+    # Old crawl_result with an extracted_event linked to an existing event.
+    old_cr = await _make_processed_crawl_result(db_session, source=source)
+    old_ee = ExtractedEvent(
+        crawl_result_id=old_cr.id, name="Old Show", location_id=location.id
+    )
+    db_session.add(old_ee)
+    await db_session.flush()
+    old_event = Event(name="Old Show", location_id=location.id)
+    db_session.add(old_event)
+    await db_session.flush()
+    # Past occurrence only -> no future grace.
+    db_session.add(
+        EventOccurrence(event_id=old_event.id, start_date=TODAY - timedelta(days=5))
+    )
+    db_session.add(
+        EventSource(
+            event_id=old_event.id,
+            extracted_event_id=old_ee.id,
+            source_id=source.id,
+            is_primary=True,
+        )
+    )
+    await db_session.flush()
+
+    # New crawl_result with a fresh unrelated event (so the orchestrator
+    # sees this source as "touched"). The old event is NOT in this crawl.
+    new_cr = await _make_processed_crawl_result(db_session, source=source)
+    await _make_extracted_event(
+        db_session,
+        crawl_result=new_cr,
+        name="Brand New Thing",
+        location=location,
+        occurrences=[_future_occ(4)],
+    )
+
+    result = await merge_extracted_events(db_session, today=TODAY)
+
+    assert result.new_events_count == 1
+    assert result.archived_count >= 1
+
+    refreshed = (
+        await db_session.execute(select(Event).where(Event.id == old_event.id))
+    ).scalar_one()
+    assert refreshed.status == EventStatus.archived
+
+
+@pytest.mark.asyncio
+async def test_merge_grace_period_preserves_future_event(
+    db_session: AsyncSession,
+) -> None:
+    source = await _make_source(db_session)
+    location = await _make_location(db_session)
+
+    old_cr = await _make_processed_crawl_result(db_session, source=source)
+    old_ee = ExtractedEvent(
+        crawl_result_id=old_cr.id, name="Far Future Show", location_id=location.id
+    )
+    db_session.add(old_ee)
+    await db_session.flush()
+    preserved = Event(name="Far Future Show", location_id=location.id)
+    db_session.add(preserved)
+    await db_session.flush()
+    # Occurrence >= today + 14 days should trigger the grace period.
+    db_session.add(
+        EventOccurrence(event_id=preserved.id, start_date=TODAY + timedelta(days=30))
+    )
+    db_session.add(
+        EventSource(
+            event_id=preserved.id,
+            extracted_event_id=old_ee.id,
+            source_id=source.id,
+            is_primary=True,
+        )
+    )
+    await db_session.flush()
+
+    new_cr = await _make_processed_crawl_result(db_session, source=source)
+    await _make_extracted_event(
+        db_session,
+        crawl_result=new_cr,
+        name="Unrelated Other",
+        location=location,
+        occurrences=[_future_occ(1)],
+    )
+
+    result = await merge_extracted_events(db_session, today=TODAY)
+
+    assert result.archived_count == 0
+    refreshed = (
+        await db_session.execute(select(Event).where(Event.id == preserved.id))
+    ).scalar_one()
+    assert refreshed.status == EventStatus.active


### PR DESCRIPTION
## What
Final PR: wire all previous pieces into the public `merge_extracted_events` async orchestrator, plus port the archiving logic (events no longer seen from any source, with 14-day future-occurrence grace period). Ports `pipeline/merger.py:387-431, 525-562, 808-868`.

## Why
This completes the port of `pipeline/merger.py` into the backend. `merge_extracted_events` is the single public entry point consumed by the pipeline consumer; `archive_outdated_events` ensures stale events are cleaned up automatically while preserving events that have upcoming occurrences within the 14-day grace window. Together they replace the standalone pipeline script with a testable, type-checked async service.

## How
- Add `MergeResult` dataclass (new_events_count, merged_count, archived_count)
- Implement `archive_outdated_events`: for each active event linked to `source_id`, check all linked sources' latest crawl; apply 14-day grace; archive and collect warnings for events archived despite upcoming occurrences
- Implement `merge_extracted_events`: load unprocessed `ExtractedEvent`s, build `DedupIndex`, iterate events (skip/log missing location or empty occurrences), build `ExtractedEventInput`, select match -> merge or create, update in-memory index for within-batch dedup, run archiving per source, commit, return `MergeResult`

## Changes
- `backend/api/services/event_merging.py`: Append `MergeResult`, `archive_outdated_events`, `merge_extracted_events`
- `backend/tests/services/test_event_merging_orchestrator.py`: Eight end-to-end async tests covering new-event creation, duplicate merging, missing-location skip, no-valid-occurrences skip, missing-source-id error, within-batch dedup, archival, and 14-day grace period

## Validation
- [x] `cd backend && uv run ruff check .`
- [x] `cd backend && uv run ruff format --check .`
- [x] `cd backend && uv run mypy .`
- [x] `cd backend && uv run pytest tests/services/test_event_merging_orchestrator.py tests/services/test_event_merging_*.py -v`

## Stack
PR 8/8 for: Port event-merging service (Issue #111)
