### PR TITLE
feat: Add USE_CELERY env var and Celery publisher

### DIFF
--- a/pipeline/celery_publisher.py
+++ b/pipeline/celery_publisher.py
@@ -1,0 +1,50 @@
+"""
+Thin Celery publisher wrapper for the pipeline.
+
+Used in USE_CELERY bridge mode to hand off post-extract processing to the
+backend worker via a Celery task.
+"""
+
+import logging
+import os
+
+from celery import Celery
+from task_names import PROCESS_CRAWL_JOB
+
+logger = logging.getLogger(__name__)
+
+
+def get_celery_app() -> Celery:
+    """Return a Celery app configured with the Redis broker.
+
+    Raises:
+        RuntimeError: If REDIS_URL environment variable is not set.
+    """
+    redis_url = os.getenv("REDIS_URL")
+    if not redis_url:
+        raise RuntimeError(
+            "USE_CELERY=true requires REDIS_URL to be set but it is missing."
+        )
+    app = Celery("pipeline-publisher", broker=redis_url)
+    app.conf.task_always_eager = False
+    return app
+
+
+def publish_process_crawl_job(crawl_job_id: int) -> str:
+    """Publish a process_crawl_job Celery task for the given crawl_job_id.
+
+    Args:
+        crawl_job_id: The ID of the crawl job to process.
+
+    Returns:
+        The Celery task ID as a string.
+    """
+    app = get_celery_app()
+    async_result = app.send_task(PROCESS_CRAWL_JOB, args=[crawl_job_id])
+    task_id: str = async_result.id
+    logger.info(
+        "Published PROCESS_CRAWL_JOB for crawl_job_id=%s task_id=%s",
+        crawl_job_id,
+        task_id,
+    )
+    return task_id

--- a/pipeline/main.py
+++ b/pipeline/main.py
@@ -17,6 +17,7 @@ Usage:
 
 import argparse
 import asyncio
+import os
 import sys
 from datetime import datetime
 
@@ -28,6 +29,8 @@ import merger
 import processor
 from crawl4ai import AsyncWebCrawler
 from extractor import TokenTracker
+
+USE_CELERY = os.getenv("USE_CELERY", "false").lower() == "true"
 
 
 async def run_pipeline(source_ids=None, limit=None):
@@ -362,6 +365,19 @@ async def run_pipeline(source_ids=None, limit=None):
                 job_tracker.merge(worker_tracker)
 
         print(f"\nExtracted events from {len(extracted_results)} source(s)\n")
+
+        if USE_CELERY:
+            from celery_publisher import publish_process_crawl_job
+
+            if job_tracker.api_calls > 0:
+                db.save_crawl_summary(cursor, crawl_job_id, job_tracker)
+            db.complete_crawl_job(cursor, connection, crawl_job_id)
+            task_id = publish_process_crawl_job(crawl_job_id)
+            print(f"{'=' * 60}")
+            print("CELERY BRIDGE MODE — handoff to backend")
+            print(f"{'=' * 60}")
+            print(f"  crawl_job_id={crawl_job_id} task_id={task_id}")
+            return True
 
         # STEP 4: Process responses
         print(f"{'=' * 60}")

--- a/pipeline/task_names.py
+++ b/pipeline/task_names.py
@@ -1,0 +1,9 @@
+"""
+Task name constants for Celery tasks.
+
+This module mirrors backend/api/task_names.py. The constants are duplicated
+here to avoid importing from the backend package. They MUST stay in sync with
+the backend constants.
+"""
+
+PROCESS_CRAWL_JOB = "backend.process_crawl_job"


### PR DESCRIPTION
Closes #113

## What
Introduce a `USE_CELERY` env var gate in `pipeline/main.py`. When `USE_CELERY=true`, the pipeline runs crawl + extract phases only, then publishes a `process_crawl_job(job_id)` Celery task to the backend via Redis. When unset/false, the legacy pipeline runs unchanged.

## Why
This is the first step in decoupling the scraper from the backend (Issue #113). The scraper should only crawl and extract; all processing, merging, and location resolution belongs in the backend Celery workers. The `USE_CELERY` flag lets us bridge the two services incrementally without breaking the existing pipeline.

## How
- Created `pipeline/task_names.py` as a local mirror of the backend's `PROCESS_CRAWL_JOB` constant — duplicated intentionally to avoid importing backend code into the scraper.
- Created `pipeline/celery_publisher.py` with `get_celery_app()` and `publish_process_crawl_job()`. Uses `Celery(broker=REDIS_URL)` with no result backend. Raises `RuntimeError` if `REDIS_URL` is missing.
- Modified `pipeline/main.py`: after the extraction step, branches on `USE_CELERY`. If true, saves crawl summary, completes the crawl job, publishes the Celery task, and returns early. Legacy path (STEP 4/5) remains fully intact.

## Changes
- `pipeline/task_names.py`: New module with `PROCESS_CRAWL_JOB = "backend.process_crawl_job"` constant — mirrors backend constant without importing it.
- `pipeline/celery_publisher.py`: Thin publisher wrapper. `get_celery_app()` validates `REDIS_URL` and returns a broker-only Celery app. `publish_process_crawl_job()` calls `send_task` and logs the task ID.
- `pipeline/main.py`: Added `USE_CELERY` env var check; inserted early-return branch after extraction for Celery mode.

## Validation
- [x] `cd pipeline && uv run ruff check .`
- [x] `cd pipeline && uv run ruff format --check .`

## Stack
PR 1/5 for: Scraper/Backend Celery Bridge (Phase 6) — Issue #113
