### PR TITLE
chore: Deploy configs for scraper REDIS_URL and backend Celery worker

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -97,6 +97,40 @@ git checkout <previous-sha>
 ./deploy/deploy.sh --only frontend
 ```
 
+## Celery Worker
+
+The pipeline and backend are connected through Redis as a Celery broker:
+
+```
+Pipeline Cloud Run Job (momaverse-pipeline)
+  → publishes backend.process_crawl_job tasks to Redis via REDIS_URL
+  → Backend worker Cloud Run Service (momaverse-backend-worker)
+      consumes tasks using api.celery_app
+```
+
+The backend worker runs the same Docker image as the API but overrides the entrypoint to run Celery instead of Uvicorn. It uses `--no-cpu-throttling` and `--min-instances=1` so it stays warm and can process tasks without cold-start delays.
+
+### Required before deploying
+
+`REDIS_URL` must be set in your shell (or CI environment) before running any deploy script:
+
+```bash
+export REDIS_URL="redis://<host>:<port>/0"
+./deploy/deploy.sh --only backend
+./deploy/deploy.sh --only pipeline
+```
+
+### Rollback
+
+For the worker, re-deploy the previous image SHA:
+
+```bash
+gcloud run deploy momaverse-backend-worker \
+  --image=<previous-image> \
+  --region=us-central1 \
+  --project=momaverse
+```
+
 ## Environment Variables
 
 These are set by `deploy.sh` and passed to component scripts. Override for standalone use:
@@ -107,5 +141,7 @@ These are set by `deploy.sh` and passed to component scripts. Override for stand
 | `REGION` | `us-central1` | GCP region |
 | `DOCKER_REPO` | `us-central1-docker.pkg.dev/momaverse/momaverse-docker` | Artifact Registry path |
 | `BACKEND_SERVICE` | `momaverse-backend` | Cloud Run service name |
+| `BACKEND_WORKER_SERVICE` | `momaverse-backend-worker` | Cloud Run service name for Celery worker |
 | `PIPELINE_JOB` | `momaverse-pipeline` | Cloud Run job name |
 | `FRONTEND_BUCKET` | `gs://momaverse-frontend` | GCS bucket for frontend |
+| `REDIS_URL` | *(required)* | Redis broker URL for Celery (no default — must be set) |

--- a/deploy/deploy-backend.sh
+++ b/deploy/deploy-backend.sh
@@ -8,7 +8,9 @@ PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 : "${PROJECT_ID:=momaverse}"
 : "${DOCKER_REPO:=us-central1-docker.pkg.dev/momaverse/momaverse-docker}"
 : "${BACKEND_SERVICE:=momaverse-backend}"
+: "${BACKEND_WORKER_SERVICE:=momaverse-backend-worker}"
 : "${REGION:=us-central1}"
+: "${REDIS_URL:?REDIS_URL must be set — backend worker consumes Celery tasks from this broker}"
 
 BACKEND_DIR="$PROJECT_ROOT/backend"
 
@@ -57,3 +59,23 @@ SERVICE_URL=$(gcloud run services describe "${BACKEND_SERVICE}" \
   --format='value(status.url)')
 echo "=== Backend deployed: ${SERVICE_URL} ==="
 echo "  Rollback: gcloud run services update-traffic ${BACKEND_SERVICE} --to-revisions=${PREV_REVISION}=100 --region=${REGION} --project=${PROJECT_ID}"
+
+echo ""
+echo "=== Deploying Backend Celery Worker ==="
+gcloud run deploy "${BACKEND_WORKER_SERVICE}" \
+  --image="${IMAGE}" \
+  --region="${REGION}" \
+  --project="${PROJECT_ID}" \
+  --command="celery" \
+  --args="-A,api.celery_app,worker,--loglevel=info,--concurrency=4" \
+  --set-env-vars="REDIS_URL=${REDIS_URL}" \
+  --no-cpu-throttling \
+  --min-instances=1
+
+echo ""
+WORKER_URL=$(gcloud run services describe "${BACKEND_WORKER_SERVICE}" \
+  --region="${REGION}" \
+  --project="${PROJECT_ID}" \
+  --format='value(status.url)')
+echo "=== Worker deployed: ${WORKER_URL} ==="
+echo "  Rollback: gcloud run deploy ${BACKEND_WORKER_SERVICE} --image=${IMAGE} --region=${REGION} --project=${PROJECT_ID} (re-deploy previous SHA)"

--- a/deploy/deploy-pipeline.sh
+++ b/deploy/deploy-pipeline.sh
@@ -9,6 +9,7 @@ PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 : "${DOCKER_REPO:=us-central1-docker.pkg.dev/momaverse/momaverse-docker}"
 : "${PIPELINE_JOB:=momaverse-pipeline}"
 : "${REGION:=us-central1}"
+: "${REDIS_URL:?REDIS_URL must be set — pipeline publishes Celery tasks to this broker}"
 
 PIPELINE_DIR="$PROJECT_ROOT/pipeline"
 
@@ -47,8 +48,10 @@ echo "=== Updating Cloud Run Job ==="
 gcloud run jobs update "${PIPELINE_JOB}" \
   --image="${IMAGE}" \
   --region="${REGION}" \
-  --project="${PROJECT_ID}"
+  --project="${PROJECT_ID}" \
+  --update-env-vars="REDIS_URL=${REDIS_URL}"
 
 echo ""
 echo "=== Pipeline deployment complete ==="
+echo "  REDIS_URL: ${REDIS_URL%%:*}://**** (redacted)"
 echo "  Rollback: gcloud run jobs update ${PIPELINE_JOB} --image=${PREV_IMAGE} --region=${REGION} --project=${PROJECT_ID}"

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -4,13 +4,24 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
 
+# === Topology ===
+# scraper (Cloud Run Job: momaverse-pipeline)
+#   → publishes backend.process_crawl_job tasks to Redis via REDIS_URL
+#   → backend worker (Cloud Run Service: momaverse-backend-worker) consumes via api.celery_app
+#   → backend API (Cloud Run Service: momaverse-backend) serves HTTP traffic
+
 # === Shared Constants ===
 export PROJECT_ID="momaverse"
 export REGION="us-central1"
 export DOCKER_REPO="us-central1-docker.pkg.dev/momaverse/momaverse-docker"
 export BACKEND_SERVICE="momaverse-backend"
+export BACKEND_WORKER_SERVICE="${BACKEND_WORKER_SERVICE:-momaverse-backend-worker}"
 export PIPELINE_JOB="momaverse-pipeline"
 export FRONTEND_BUCKET="gs://momaverse-frontend"
+
+# === Required Env Vars ===
+: "${REDIS_URL:?REDIS_URL must be set — required by pipeline (publish) and backend worker (consume)}"
+export REDIS_URL
 
 # === Pre-flight Checks ===
 require_cmd() {


### PR DESCRIPTION
close #113 
## What
Update deployment scripts to wire `REDIS_URL` into the scraper Cloud Run Job and provision a dedicated Celery worker Cloud Run Service for the backend.

## Why
The scraper now requires `REDIS_URL` to publish tasks, and the backend needs a running Celery worker to consume them. Without these deploy-time changes, the Celery bridge introduced in PR1–PR4 would silently fail in production because neither service would be configured with the broker URL.

## How
- Added `REDIS_URL` pre-flight check and `--update-env-vars` flag to `deploy/deploy-pipeline.sh`.
- Added a second `gcloud run deploy` block in `deploy/deploy-backend.sh` targeting a dedicated `momaverse-backend-worker` service with the same image but a Celery worker entrypoint (`--concurrency=4`, `--min-instances=1`, `--no-cpu-throttling`).
- Added `REDIS_URL` export and topology comment to `deploy/deploy.sh`.
- Updated `deploy/README.md` with a "Celery worker" section documenting required env vars and rollback procedure.

## Changes
- `deploy/deploy-pipeline.sh`: Pre-flight check for `REDIS_URL`; passes it via `--update-env-vars` to the Cloud Run Job; echoes redacted value in deploy summary.
- `deploy/deploy-backend.sh`: Pre-flight checks for broker vars; second deploy block for `momaverse-backend-worker` with Celery entrypoint, worker URL echo, and rollback hint.
- `deploy/deploy.sh`: `REDIS_URL` added to env exports; topology comment block added.
- `deploy/README.md`: "Celery worker" section with topology diagram, required env vars, and rollback instructions.

## Validation
- [x] `bash -n deploy/deploy-pipeline.sh`
- [x] `bash -n deploy/deploy-backend.sh`
- [x] `bash -n deploy/deploy.sh`
- [x] `cd backend && uv run ruff check . && uv run pytest`

## Stack
PR 5/5 for: Scraper/Backend Celery Bridge (Phase 6) — Issue #113
